### PR TITLE
feat: enhance template selector with filters and preview

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -41,7 +41,8 @@ import {
   deleteSurgeryTemplateById,
   listSurgeryTemplates,
   searchTemplatesForEditor,
-  getTemplateCategories
+  getTemplateCategories,
+  getTemplateTags
 } from './repository/surgery-template'
 
 // Custom APIs for renderer
@@ -83,7 +84,8 @@ export const api = {
   deleteSurgeryTemplateById,
   listSurgeryTemplates,
   searchTemplatesForEditor,
-  getTemplateCategories
+  getTemplateCategories,
+  getTemplateTags
 }
 
 export type ApiType = typeof api

--- a/src/renderer/src/components/common/FilterCombobox.tsx
+++ b/src/renderer/src/components/common/FilterCombobox.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { Check, ChevronsUpDown, X } from 'lucide-react'
+import { cn } from '@renderer/lib/utils'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@renderer/components/ui/command'
+
+export interface FilterComboboxItem {
+  value: string
+  label: string
+}
+
+interface FilterComboboxProps {
+  items: FilterComboboxItem[]
+  value: string | null
+  onChange: (value: string | null) => void
+  placeholder: string
+  searchPlaceholder?: string
+  emptyText?: string
+  className?: string
+}
+
+export const FilterCombobox = ({
+  items,
+  value,
+  onChange,
+  placeholder,
+  searchPlaceholder = 'Search...',
+  emptyText = 'No items found.',
+  className
+}: FilterComboboxProps) => {
+  const [open, setOpen] = useState(false)
+
+  const selectedItem = items.find((item) => item.value === value)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn('justify-between text-sm font-normal', className)}
+        >
+          <span className={cn('truncate', !selectedItem && 'text-muted-foreground')}>
+            {selectedItem?.label ?? placeholder}
+          </span>
+          <div className="flex items-center gap-1 ml-2 shrink-0">
+            {value && (
+              <X
+                className="h-3 w-3 opacity-50 hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onChange(null)
+                }}
+              />
+            )}
+            <ChevronsUpDown className="h-4 w-4 opacity-50" />
+          </div>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {items.map((item) => (
+                <CommandItem
+                  key={item.value}
+                  value={item.value}
+                  onSelect={() => {
+                    onChange(item.value === value ? null : item.value)
+                    setOpen(false)
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      'mr-2 h-4 w-4',
+                      value === item.value ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  {item.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/common/RichTextEditor.tsx
+++ b/src/renderer/src/components/common/RichTextEditor.tsx
@@ -187,6 +187,7 @@ const MenuBar = ({ editor, showTemplateButton = true, onTemplateClick }: MenuBar
         <div className="p-1 w-fit flex space-x-1">
           <ToolbarButton onClick={onTemplateClick} title="Insert template">
             <FileText className="h-4 w-4" />
+            <span className="ml-1 text-xs">Templates</span>
           </ToolbarButton>
         </div>
       )}

--- a/src/renderer/src/components/common/TemplateSelector.tsx
+++ b/src/renderer/src/components/common/TemplateSelector.tsx
@@ -1,21 +1,27 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Globe, User } from 'lucide-react'
-import {
-  CommandDialog,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList
-} from '@renderer/components/ui/command'
+import { Globe, User, Search } from 'lucide-react'
+import { Dialog, DialogContent } from '@renderer/components/ui/dialog'
 import { Badge } from '@renderer/components/ui/badge'
-import { unwrapResult } from '@renderer/lib/utils'
+import { Input } from '@renderer/components/ui/input'
+import { FilterCombobox, FilterComboboxItem } from './FilterCombobox'
+import { queries } from '@renderer/lib/queries'
+import { cn } from '@renderer/lib/utils'
 
 interface TemplateSelectorProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSelect: (content: string) => void
+}
+
+interface TemplateItem {
+  id: number
+  title: string
+  content: string
+  category: string
+  tags: string[]
+  doctorId: number | null
+  doctorName: string | null
 }
 
 // Strip HTML tags for preview
@@ -35,6 +41,12 @@ const truncate = (text: string, maxLength: number): string => {
 export const TemplateSelector = ({ open, onOpenChange, onSelect }: TemplateSelectorProps) => {
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
+  const [doctorFilter, setDoctorFilter] = useState<string | null>(null)
+  const [tagFilter, setTagFilter] = useState<string | null>(null)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+  const selectedRef = useRef<HTMLDivElement>(null)
 
   // Debounce search input
   useEffect(() => {
@@ -42,94 +54,280 @@ export const TemplateSelector = ({ open, onOpenChange, onSelect }: TemplateSelec
     return () => clearTimeout(timer)
   }, [search])
 
-  // Reset search when dialog closes
+  // Reset state when dialog closes
   useEffect(() => {
     if (!open) {
       setSearch('')
       setDebouncedSearch('')
+      setCategoryFilter(null)
+      setDoctorFilter(null)
+      setTagFilter(null)
+      setSelectedIndex(0)
     }
   }, [open])
 
-  const { data: templatesGrouped, isLoading } = useQuery({
-    queryKey: ['surgeryTemplates', 'forEditor', debouncedSearch],
-    queryFn: () =>
-      unwrapResult(
-        window.api.invoke('searchTemplatesForEditor', {
-          search: debouncedSearch || undefined
-        })
-      ),
+  // Fetch templates with filters
+  const { data: templates = [], isLoading: templatesLoading } = useQuery({
+    ...queries.surgeryTemplates.forEditor({
+      search: debouncedSearch || undefined,
+      category: categoryFilter || undefined,
+      doctorId: doctorFilter ? parseInt(doctorFilter, 10) : undefined,
+      tag: tagFilter || undefined
+    }),
     enabled: open
   })
 
-  const categories = useMemo(() => {
-    if (!templatesGrouped) return []
-    return Object.keys(templatesGrouped).sort()
-  }, [templatesGrouped])
+  // Fetch categories for filter
+  const { data: categories = [] } = useQuery({
+    ...queries.surgeryTemplates.categories,
+    enabled: open
+  })
 
-  const handleSelect = (content: string) => {
-    onSelect(content)
-    onOpenChange(false)
-  }
+  // Fetch tags for filter
+  const { data: tags = [] } = useQuery({
+    ...queries.surgeryTemplates.tags,
+    enabled: open
+  })
+
+  // Fetch doctors for filter
+  const { data: doctorsResult } = useQuery({
+    ...queries.doctors.list({ pageSize: 100 }),
+    enabled: open
+  })
+
+  // Transform data for filter comboboxes
+  const categoryItems: FilterComboboxItem[] = useMemo(
+    () => categories.map((c: string) => ({ value: c, label: c })),
+    [categories]
+  )
+
+  const tagItems: FilterComboboxItem[] = useMemo(
+    () => tags.map((t: string) => ({ value: t, label: t })),
+    [tags]
+  )
+
+  const doctorItems: FilterComboboxItem[] = useMemo(
+    () =>
+      doctorsResult?.data?.map((d: { id: number; name: string }) => ({
+        value: String(d.id),
+        label: d.name
+      })) || [],
+    [doctorsResult]
+  )
+
+  // Reset selected index when templates change
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [templates])
+
+  const selectedTemplate: TemplateItem | null = templates[selectedIndex] || null
+
+  const handleSelect = useCallback(
+    (content: string) => {
+      onSelect(content)
+      onOpenChange(false)
+    },
+    [onSelect, onOpenChange]
+  )
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelectedIndex((prev) => Math.min(prev + 1, templates.length - 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelectedIndex((prev) => Math.max(prev - 1, 0))
+      } else if (e.key === 'Enter' && selectedTemplate) {
+        e.preventDefault()
+        handleSelect(selectedTemplate.content)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, templates.length, selectedTemplate, handleSelect])
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (selectedRef.current) {
+      selectedRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }
+  }, [selectedIndex])
 
   return (
-    <CommandDialog open={open} onOpenChange={onOpenChange}>
-      <CommandInput placeholder="Search templates..." value={search} onValueChange={setSearch} />
-      <CommandList className="max-h-[400px]">
-        {isLoading ? (
-          <div className="py-6 text-center text-sm text-muted-foreground">Loading templates...</div>
-        ) : categories.length === 0 ? (
-          <CommandEmpty>
-            {debouncedSearch
-              ? 'No templates found matching your search.'
-              : 'No templates available. Create templates in Settings.'}
-          </CommandEmpty>
-        ) : (
-          categories.map((category) => (
-            <CommandGroup key={category} heading={category.toUpperCase()}>
-              {templatesGrouped?.[category].map((template) => (
-                <CommandItem
-                  key={template.id}
-                  value={`${template.title} ${template.category} ${template.tags.join(' ')}`}
-                  onSelect={() => handleSelect(template.content)}
-                  className="flex flex-col items-start gap-1 py-3"
-                >
-                  <div className="flex items-center justify-between w-full">
-                    <span className="font-medium">{template.title}</span>
-                    {template.doctorId === null ? (
-                      <span title="Global template">
-                        <Globe className="h-3.5 w-3.5 text-muted-foreground" />
-                      </span>
-                    ) : (
-                      <div
-                        className="flex items-center gap-1 text-muted-foreground"
-                        title={`Doctor: ${template.doctorName}`}
-                      >
-                        <User className="h-3.5 w-3.5" />
-                        <span className="text-xs">{template.doctorName}</span>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl p-0 gap-0 overflow-hidden h-[600px] flex flex-col">
+        {/* Search input */}
+        <div className="flex items-center border-b px-3">
+          <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <Input
+            placeholder="Search templates..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="flex h-11 w-full rounded-none border-0 bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
+            autoFocus
+          />
+        </div>
+
+        {/* Filter row */}
+        <div className="flex items-center gap-2 px-3 py-2 border-b bg-muted/30">
+          <FilterCombobox
+            items={categoryItems}
+            value={categoryFilter}
+            onChange={setCategoryFilter}
+            placeholder="Category"
+            searchPlaceholder="Search categories..."
+            emptyText="No categories found."
+            className="w-[140px] h-8"
+          />
+          <FilterCombobox
+            items={doctorItems}
+            value={doctorFilter}
+            onChange={setDoctorFilter}
+            placeholder="Doctor"
+            searchPlaceholder="Search doctors..."
+            emptyText="No doctors found."
+            className="w-[160px] h-8"
+          />
+          <FilterCombobox
+            items={tagItems}
+            value={tagFilter}
+            onChange={setTagFilter}
+            placeholder="Tag"
+            searchPlaceholder="Search tags..."
+            emptyText="No tags found."
+            className="w-[140px] h-8"
+          />
+        </div>
+
+        {/* Main content area */}
+        <div className="flex flex-1 min-h-0">
+          {/* Template list */}
+          <div className="w-[40%] border-r flex flex-col">
+            <div ref={listRef} className="flex-1 overflow-y-auto">
+              {templatesLoading ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  Loading templates...
+                </div>
+              ) : templates.length === 0 ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  {debouncedSearch || categoryFilter || doctorFilter || tagFilter
+                    ? 'No templates found matching your filters.'
+                    : 'No templates available. Create templates in Settings.'}
+                </div>
+              ) : (
+                <div className="p-2">
+                  {templates.map((template: TemplateItem, index: number) => (
+                    <div
+                      key={template.id}
+                      ref={index === selectedIndex ? selectedRef : null}
+                      className={cn(
+                        'p-3 rounded-md cursor-pointer transition-colors mb-1',
+                        index === selectedIndex
+                          ? 'bg-accent text-accent-foreground'
+                          : 'hover:bg-muted'
+                      )}
+                      onClick={() => setSelectedIndex(index)}
+                      onDoubleClick={() => handleSelect(template.content)}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium truncate">{template.title}</span>
+                        <div className="flex items-center gap-1 shrink-0">
+                          <Badge variant="outline" className="text-xs px-1.5 py-0">
+                            {template.category}
+                          </Badge>
+                          {template.doctorId === null ? (
+                            <span title="Global template">
+                              <Globe className="h-3 w-3 text-muted-foreground" />
+                            </span>
+                          ) : (
+                            <span title={`Doctor: ${template.doctorName}`}>
+                              <User className="h-3 w-3 text-muted-foreground" />
+                            </span>
+                          )}
+                        </div>
                       </div>
-                    )}
+                      {template.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {template.tags.slice(0, 3).map((tag) => (
+                            <Badge
+                              key={tag}
+                              variant="secondary"
+                              className="text-xs px-1.5 py-0 font-normal"
+                            >
+                              {tag}
+                            </Badge>
+                          ))}
+                          {template.tags.length > 3 && (
+                            <Badge variant="secondary" className="text-xs px-1.5 py-0 font-normal">
+                              +{template.tags.length - 3}
+                            </Badge>
+                          )}
+                        </div>
+                      )}
+                      <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                        {truncate(stripHtml(template.content), 80)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Preview panel */}
+          <div className="w-[60%] flex flex-col">
+            <div className="px-4 py-2 border-b bg-muted/30">
+              <h3 className="text-sm font-medium">Template Preview</h3>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {selectedTemplate ? (
+                <div className="p-4">
+                  <div className="flex items-center justify-between mb-3">
+                    <h4 className="text-lg font-semibold">{selectedTemplate.title}</h4>
+                    <Badge variant="outline">{selectedTemplate.category}</Badge>
                   </div>
-                  {template.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {template.tags.map((tag) => (
-                        <Badge key={tag} variant="secondary" className="text-xs px-1.5 py-0">
+                  {selectedTemplate.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mb-3">
+                      {selectedTemplate.tags.map((tag) => (
+                        <Badge key={tag} variant="secondary" className="text-xs">
                           {tag}
                         </Badge>
                       ))}
                     </div>
                   )}
-                  <p className="text-xs text-muted-foreground line-clamp-2">
-                    {truncate(stripHtml(template.content), 100)}
-                  </p>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          ))
-        )}
-      </CommandList>
-      <div className="border-t px-3 py-2 text-xs text-muted-foreground">
-        Type to search &bull; Use arrow keys to navigate &bull; Press Enter to insert
-      </div>
-    </CommandDialog>
+                  {selectedTemplate.doctorName && (
+                    <div className="flex items-center gap-1 text-sm text-muted-foreground mb-3">
+                      <User className="h-3.5 w-3.5" />
+                      <span>{selectedTemplate.doctorName}</span>
+                    </div>
+                  )}
+                  <div className="border-t pt-3">
+                    <div
+                      className="prose prose-sm dark:prose-invert max-w-none template-preview"
+                      dangerouslySetInnerHTML={{ __html: selectedTemplate.content }}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                  Select a template to preview
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t px-3 py-2 text-xs text-muted-foreground bg-muted/30">
+          Type to search &bull; Use arrow keys to navigate &bull; Press Enter to insert &bull;
+          Double-click to insert
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -82,4 +82,107 @@
     height: 0;
     pointer-events: none;
   }
+
+  /* Template preview styles */
+  .template-preview {
+    font-family: system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    color: hsl(var(--foreground));
+  }
+
+  .template-preview h1,
+  .template-preview h2,
+  .template-preview h3,
+  .template-preview h4,
+  .template-preview h5,
+  .template-preview h6 {
+    color: hsl(var(--foreground));
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+    font-weight: 600;
+  }
+
+  .template-preview h1 { font-size: 1.75rem; }
+  .template-preview h2 { font-size: 1.5rem; }
+  .template-preview h3 { font-size: 1.25rem; }
+  .template-preview h4 { font-size: 1.125rem; }
+  .template-preview h5 { font-size: 1rem; }
+  .template-preview h6 { font-size: 0.875rem; }
+
+  .template-preview p {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+  }
+
+  .template-preview ul,
+  .template-preview ol {
+    margin-left: 1.5em;
+    margin-bottom: 0.5em;
+  }
+
+  .template-preview ul {
+    list-style-type: disc;
+  }
+
+  .template-preview ol {
+    list-style-type: decimal;
+  }
+
+  .template-preview li {
+    margin-bottom: 0.25em;
+  }
+
+  .template-preview blockquote {
+    border-left: 3px solid hsl(var(--border));
+    padding-left: 1em;
+    margin: 0.5em 0;
+    color: hsl(var(--muted-foreground));
+    font-style: italic;
+  }
+
+  .template-preview strong,
+  .template-preview b {
+    font-weight: 600;
+  }
+
+  .template-preview em,
+  .template-preview i {
+    font-style: italic;
+  }
+
+  .template-preview a {
+    color: hsl(var(--primary));
+    text-decoration: underline;
+  }
+
+  .template-preview code {
+    background-color: hsl(var(--muted));
+    padding: 0.125em 0.25em;
+    border-radius: 0.25em;
+    font-size: 0.875em;
+  }
+
+  .template-preview pre {
+    background-color: hsl(var(--muted));
+    padding: 0.75em;
+    border-radius: 0.375em;
+    overflow-x: auto;
+  }
+
+  .template-preview table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5em 0;
+  }
+
+  .template-preview th,
+  .template-preview td {
+    border: 1px solid hsl(var(--border));
+    padding: 0.5em;
+  }
+
+  .template-preview th {
+    background-color: hsl(var(--muted));
+    font-weight: 600;
+  }
 }

--- a/src/renderer/src/lib/queries.ts
+++ b/src/renderer/src/lib/queries.ts
@@ -61,14 +61,22 @@ export const queries = createQueryKeyStore({
       queryKey: [id],
       queryFn: () => unwrapResult(window.api.invoke('getSurgeryTemplateById', id))
     }),
-    forEditor: (search?: string, doctorId?: number) => ({
-      queryKey: [search, doctorId],
-      queryFn: () =>
-        unwrapResult(window.api.invoke('searchTemplatesForEditor', { search, doctorId }))
+    forEditor: (params: {
+      search?: string
+      doctorId?: number
+      category?: string
+      tag?: string
+    }) => ({
+      queryKey: [params],
+      queryFn: () => unwrapResult(window.api.invoke('searchTemplatesForEditor', params))
     }),
     categories: {
       queryKey: null,
       queryFn: () => unwrapResult(window.api.invoke('getTemplateCategories'))
+    },
+    tags: {
+      queryKey: null,
+      queryFn: () => unwrapResult(window.api.invoke('getTemplateTags'))
     }
   }
 })


### PR DESCRIPTION
## Summary
- Add filter dropdowns for category, doctor, and tag to the template selector
- Add a preview panel on the right showing full template content with proper styling
- Add "Templates" label to the toolbar button for clarity

## Changes
- **New component**: `FilterCombobox` - reusable filter combobox with type-to-search
- **API**: Added `getTemplateTags()` to fetch distinct tags across templates
- **API**: Extended `searchTemplatesForEditor()` to accept category and tag filter parameters
- **UI**: Redesigned template selector with split view (40% list, 60% preview)
- **Styles**: Added template preview styles for light/dark mode support

## Test plan
- [ ] Open template selector in surgery editor
- [ ] Verify category filter works (type to search, select to filter)
- [ ] Verify doctor filter works (type doctor name, select to filter)
- [ ] Verify tag filter works (type to filter, select to filter)
- [ ] Verify filters combine correctly (AND logic)
- [ ] Verify template list shows flat list with category badges
- [ ] Verify selecting a template shows preview on the right
- [ ] Verify preview content is properly styled
- [ ] Verify search + filters work together
- [ ] Verify Enter key inserts selected template
- [ ] Verify double-click inserts template