### PR TITLE
feat: add follow-up print functionality

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,9 @@ name: Build Electron app
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
   pull_request:
 
 concurrency:
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22"
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: main
-          commit_message: 'chore: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
+          commit_message: "chore: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]"
           file_pattern: CHANGELOG.md
 
   release:
@@ -60,12 +60,12 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "22"
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm

--- a/resources/templates/followup.hbs
+++ b/resources/templates/followup.hbs
@@ -1,0 +1,75 @@
+<div class='document'>
+  <!-- Header Section -->
+  <div class='header-section keep-together'>
+    <h1 class='text-2xl bold'>
+      {{settings.hospital}}
+    </h1>
+    <h2 class='text-lg pt-1'>
+      {{settings.unit}}
+    </h2>
+    {{#if settings.telephone}}
+      <p class='text-sm pt-1'>
+        Tel: {{settings.telephone}}
+      </p>
+    {{/if}}
+  </div>
+
+  <!-- Patient Info Table -->
+  <table class='info-table keep-together'>
+    <tr>
+      <td class='label'>Name:</td>
+      <td colspan='3'>{{patient.name}}</td>
+    </tr>
+    <tr>
+      <td class='label'>BHT:</td>
+      <td>{{surgery.bht}}</td>
+      <td class='label'>Date:</td>
+      <td>{{surgery.date}}</td>
+    </tr>
+    <tr>
+      <td class='label'>Age/Sex:</td>
+      <td>{{patient.age}} / {{patient.gender}}</td>
+      <td class='label'>Ward:</td>
+      <td>{{surgery.ward}}</td>
+    </tr>
+    {{#if surgery.doa}}{{#if surgery.dod}}
+    <tr>
+      <td class='label'>DoA:</td>
+      <td>{{surgery.doa}}</td>
+      <td class='label'>DoD:</td>
+      <td>{{surgery.dod}}</td>
+    </tr>
+    {{/if}}{{/if}}
+    {{#if surgery.doa}}{{#unless surgery.dod}}
+    <tr>
+      <td class='label'>DoA:</td>
+      <td colspan='3'>{{surgery.doa}}</td>
+    </tr>
+    {{/unless}}{{/if}}
+    {{#unless surgery.doa}}{{#if surgery.dod}}
+    <tr>
+      <td class='label'>DoD:</td>
+      <td colspan='3'>{{surgery.dod}}</td>
+    </tr>
+    {{/if}}{{/unless}}
+  </table>
+
+  <!-- Follow-up Title -->
+  <div class='surgery-title keep-together'>
+    <h2 class='text-lg text-center bold'>
+      Follow-up Notes
+    </h2>
+    <p class='text-sm text-center'>
+      {{followup.date}}
+    </p>
+  </div>
+
+  <!-- Follow-up Notes Section -->
+  {{#if followup.notes}}
+    <div class='notes-section'>
+      <div class='prose'>
+        {{{followup.notes}}}
+      </div>
+    </div>
+  {{/if}}
+</div>

--- a/src/renderer/src/lib/print.ts
+++ b/src/renderer/src/lib/print.ts
@@ -1,12 +1,14 @@
 import { PatientModel } from '@shared/models/PatientModel'
 import { SurgeryModel } from '@shared/models/SurgeryModel'
-import { formatDate, isEmptyHtml } from './utils'
+import { FollowupModel } from '@shared/models/FollowupModel'
+import { formatDate, formatDateTime, isEmptyHtml } from './utils'
 
 export const surgeryPrintData = (
   patient?: PatientModel,
   surgery?: SurgeryModel,
   settings?: Record<string, string | null>
 ) => ({
+  template: 'surgery',
   patient: {
     ...patient,
     age: patient?.age ? `${patient?.age} yrs` : `<1 yrs`
@@ -30,6 +32,35 @@ export const surgeryPrintData = (
     dod: surgery?.dod ? formatDate(surgery?.dod) : null,
     notes: isEmptyHtml(surgery?.notes) ? null : surgery?.notes,
     post_op_notes: isEmptyHtml(surgery?.post_op_notes) ? null : surgery?.post_op_notes
+  },
+  settings: {
+    hospital: settings?.hospital || '',
+    unit: settings?.unit || '',
+    telephone: settings?.telephone || ''
+  }
+})
+
+export const followupPrintData = (
+  patient?: PatientModel,
+  surgery?: SurgeryModel,
+  followup?: FollowupModel,
+  settings?: Record<string, string | null>
+) => ({
+  template: 'followup',
+  patient: {
+    ...patient,
+    age: patient?.age ? `${patient?.age} yrs` : `<1 yrs`
+  },
+  surgery: {
+    bht: surgery?.bht || '',
+    ward: surgery?.ward || '',
+    date: surgery?.date ? formatDate(surgery.date) : null,
+    doa: surgery?.doa ? formatDate(surgery.doa) : null,
+    dod: surgery?.dod ? formatDate(surgery.dod) : null
+  },
+  followup: {
+    date: followup?.created_at ? formatDateTime(followup.created_at) : '',
+    notes: isEmptyHtml(followup?.notes) ? null : followup?.notes
   },
   settings: {
     hospital: settings?.hospital || '',

--- a/src/renderer/src/print.tsx
+++ b/src/renderer/src/print.tsx
@@ -6,8 +6,12 @@ import React, { useEffect, useMemo } from 'react'
 import ReactDOM from 'react-dom/client'
 import handlebars from 'handlebars'
 import surgeryOpNoteTemplate from '../../../resources/templates/surgery-opnote.hbs?raw'
+import followupTemplate from '../../../resources/templates/followup.hbs?raw'
 
-const printTemplate = handlebars.compile(surgeryOpNoteTemplate)
+const templates: Record<string, HandlebarsTemplateDelegate> = {
+  surgery: handlebars.compile(surgeryOpNoteTemplate),
+  followup: handlebars.compile(followupTemplate)
+}
 
 const Print = () => {
   const [printData, setPrintData] = React.useState<object | null>(null)
@@ -23,7 +27,10 @@ const Print = () => {
     if (!printData) {
       return ''
     }
-    return printTemplate((printData as any).data)
+    const data = (printData as any).data
+    const templateName = data.template || 'surgery'
+    const template = templates[templateName] || templates.surgery
+    return template(data)
   }, [printData])
 
   const handlePrint = () => {


### PR DESCRIPTION
## Summary
- Add print button to each follow-up card in the surgery view
- Create new Handlebars template for follow-up printouts with full hospital header
- Support multiple print templates via template selection in print renderer
- Print includes hospital info, patient details, surgery info (BHT, date, ward, DoA/DoD), and follow-up notes

## Test plan
- [ ] Navigate to a surgery with follow-ups
- [ ] Click the print icon (outline button) on a follow-up card
- [ ] Verify print window shows hospital header, patient info, surgery details, and follow-up notes
- [ ] Click Print or Ctrl+P to verify output
- [ ] Verify existing surgery print still works (no regression)