### PR TITLE
feat: add database backup and restore functionality

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -44,6 +44,7 @@ import {
   getTemplateCategories,
   getTemplateTags
 } from './repository/surgery-template'
+import { createBackup, listBackups, deleteBackup, restoreBackup } from './backup'
 
 // Custom APIs for renderer
 export const api = {
@@ -85,7 +86,12 @@ export const api = {
   listSurgeryTemplates,
   searchTemplatesForEditor,
   getTemplateCategories,
-  getTemplateTags
+  getTemplateTags,
+
+  createBackup,
+  listBackups,
+  deleteBackup,
+  restoreBackup
 }
 
 export type ApiType = typeof api

--- a/src/main/backup.ts
+++ b/src/main/backup.ts
@@ -1,0 +1,277 @@
+import { app } from 'electron'
+import { join } from 'path'
+import { copyFile, mkdir, readdir, stat, unlink } from 'fs/promises'
+import log from 'electron-log'
+import { DB_PATH, db } from './db'
+import { BackupInfo, BackupReason, BackupResult } from '../shared/types/backup'
+
+const DEFAULT_BACKUP_FOLDER = join(app.getPath('userData'), 'backups')
+const MAX_BACKUPS = 10
+const HOURLY_MS = 60 * 60 * 1000
+
+let schedulerInterval: NodeJS.Timeout | null = null
+
+function formatDate(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}_${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}`
+}
+
+export async function getBackupFolder(): Promise<string> {
+  const result = await db
+    .selectFrom('app_settings')
+    .select('value')
+    .where('key', '=', 'backup_folder')
+    .executeTakeFirst()
+
+  return result?.value || DEFAULT_BACKUP_FOLDER
+}
+
+async function ensureBackupFolder(): Promise<string> {
+  const folder = await getBackupFolder()
+  await mkdir(folder, { recursive: true })
+  return folder
+}
+
+async function updateLastBackupTime(): Promise<void> {
+  const now = new Date().toISOString()
+  await db
+    .updateTable('app_settings')
+    .set({ value: now })
+    .where('key', '=', 'last_backup_time')
+    .execute()
+}
+
+export async function createBackup(reason: BackupReason): Promise<BackupResult> {
+  try {
+    log.info(`Creating backup (reason: ${reason})`)
+    const folder = await ensureBackupFolder()
+    const timestamp = formatDate(new Date())
+    const filename = `data_${timestamp}.db`
+    const backupPath = join(folder, filename)
+
+    await copyFile(DB_PATH, backupPath)
+    await updateLastBackupTime()
+
+    log.info(`Backup created: ${backupPath}`)
+
+    // Cleanup old backups after creating a new one
+    await cleanupOldBackups()
+
+    return { success: true, path: backupPath }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    log.error('Backup failed:', error)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function listBackups(): Promise<BackupInfo[]> {
+  try {
+    const folder = await getBackupFolder()
+
+    let files: string[]
+    try {
+      files = await readdir(folder)
+    } catch {
+      // Folder doesn't exist yet
+      return []
+    }
+
+    const backups: BackupInfo[] = []
+
+    for (const file of files) {
+      if (!file.endsWith('.db') || !file.startsWith('data_')) {
+        continue
+      }
+
+      const filePath = join(folder, file)
+      const fileStat = await stat(filePath)
+
+      // Extract timestamp from filename (data_YYYY-MM-DD_HH-mm-ss.db)
+      const match = file.match(/data_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})\.db/)
+      const timestamp = match
+        ? match[1].replace(/_/g, 'T').replace(/-(\d{2})-(\d{2})$/, ':$1:$2')
+        : fileStat.mtime.toISOString()
+
+      backups.push({
+        filename: file,
+        path: filePath,
+        timestamp,
+        size: fileStat.size
+      })
+    }
+
+    // Sort by timestamp descending (newest first)
+    backups.sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+
+    return backups
+  } catch (error) {
+    log.error('Error listing backups:', error)
+    return []
+  }
+}
+
+export async function deleteBackup(filename: string): Promise<boolean> {
+  try {
+    const folder = await getBackupFolder()
+    const filePath = join(folder, filename)
+
+    // Security check: ensure filename is valid
+    if (!filename.startsWith('data_') || !filename.endsWith('.db')) {
+      log.error('Invalid backup filename:', filename)
+      return false
+    }
+
+    await unlink(filePath)
+    log.info(`Deleted backup: ${filePath}`)
+    return true
+  } catch (error) {
+    log.error('Error deleting backup:', error)
+    return false
+  }
+}
+
+export async function cleanupOldBackups(maxToKeep: number = MAX_BACKUPS): Promise<void> {
+  try {
+    const backups = await listBackups()
+
+    if (backups.length <= maxToKeep) {
+      return
+    }
+
+    // Delete backups beyond the max limit (list is already sorted newest first)
+    const toDelete = backups.slice(maxToKeep)
+
+    for (const backup of toDelete) {
+      await unlink(backup.path)
+      log.info(`Cleaned up old backup: ${backup.filename}`)
+    }
+  } catch (error) {
+    log.error('Error cleaning up old backups:', error)
+  }
+}
+
+async function isBackupEnabled(): Promise<boolean> {
+  const result = await db
+    .selectFrom('app_settings')
+    .select('value')
+    .where('key', '=', 'backup_enabled')
+    .executeTakeFirst()
+
+  return result?.value === 'true'
+}
+
+async function getLastBackupTime(): Promise<Date | null> {
+  const result = await db
+    .selectFrom('app_settings')
+    .select('value')
+    .where('key', '=', 'last_backup_time')
+    .executeTakeFirst()
+
+  return result?.value ? new Date(result.value) : null
+}
+
+export async function initBackupScheduler(): Promise<void> {
+  const enabled = await isBackupEnabled()
+  if (!enabled) {
+    log.info('Backup scheduler not started: backups are disabled')
+    return
+  }
+
+  const lastBackup = await getLastBackupTime()
+  const now = Date.now()
+
+  let delay: number
+
+  if (lastBackup) {
+    const timeSinceLast = now - lastBackup.getTime()
+    if (timeSinceLast >= HOURLY_MS) {
+      // More than an hour since last backup, backup immediately
+      delay = 0
+    } else {
+      // Wait until the hour completes
+      delay = HOURLY_MS - timeSinceLast
+    }
+  } else {
+    // No previous backup, start immediately
+    delay = 0
+  }
+
+  log.info(`Backup scheduler starting. First backup in ${Math.round(delay / 1000)}s`)
+
+  // Schedule first backup
+  setTimeout(async () => {
+    await runScheduledBackup()
+    // Then start hourly interval
+    schedulerInterval = setInterval(runScheduledBackup, HOURLY_MS)
+  }, delay)
+}
+
+async function runScheduledBackup(): Promise<void> {
+  const enabled = await isBackupEnabled()
+  if (!enabled) {
+    log.info('Skipping scheduled backup: backups are disabled')
+    return
+  }
+
+  log.info('Running scheduled backup')
+  await createBackup('scheduled')
+}
+
+export function stopBackupScheduler(): void {
+  if (schedulerInterval) {
+    clearInterval(schedulerInterval)
+    schedulerInterval = null
+    log.info('Backup scheduler stopped')
+  }
+}
+
+export async function restartBackupScheduler(): Promise<void> {
+  stopBackupScheduler()
+  await initBackupScheduler()
+}
+
+export async function exportBackupToPath(destinationPath: string): Promise<BackupResult> {
+  try {
+    log.info(`Exporting backup to: ${destinationPath}`)
+    await copyFile(DB_PATH, destinationPath)
+    log.info(`Backup exported successfully: ${destinationPath}`)
+    return { success: true, path: destinationPath }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    log.error('Export backup failed:', error)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function restoreBackup(backupPath: string): Promise<BackupResult> {
+  try {
+    log.info(`Restoring backup from: ${backupPath}`)
+
+    // 1. Validate backup file exists
+    try {
+      await stat(backupPath)
+    } catch {
+      return { success: false, error: 'Backup file does not exist' }
+    }
+
+    // 2. Create safety backup of current DB before restore
+    const folder = await ensureBackupFolder()
+    const timestamp = formatDate(new Date())
+    const safetyFilename = `data_pre_restore_${timestamp}.db`
+    const safetyPath = join(folder, safetyFilename)
+
+    await copyFile(DB_PATH, safetyPath)
+    log.info(`Safety backup created: ${safetyPath}`)
+
+    // 3. Copy backup file to DB_PATH (overwrite)
+    await copyFile(backupPath, DB_PATH)
+    log.info(`Database restored from: ${backupPath}`)
+
+    return { success: true, path: DB_PATH }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    log.error('Restore backup failed:', error)
+    return { success: false, error: errorMessage }
+  }
+}

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -7,7 +7,7 @@ import { MemoryMigrationProvider } from './db/memory-migration-provider'
 import { app } from 'electron'
 import log from 'electron-log'
 
-const DB_PATH = join(app.getPath('userData'), 'data.db')
+export const DB_PATH = join(app.getPath('userData'), 'data.db')
 log.info('DB_PATH:', DB_PATH)
 
 const dialect = new SqliteDialect({

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -3,11 +3,13 @@ import * as m_001_app_settings from './migrations/001_app_settings'
 import * as m_002_telephone_setting from './migrations/002_telephone_setting'
 import * as m_003_doa_dod from './migrations/003_doa_dod'
 import * as m_004_surgery_templates from './migrations/004_surgery_templates'
+import * as m_005_backup_settings from './migrations/005_backup_settings'
 
 export default {
   '000_init': m_000_init,
   '001_app_settings': m_001_app_settings,
   '002_telephone_setting': m_002_telephone_setting,
   '003_doa_dod': m_003_doa_dod,
-  '004_surgery_templates': m_004_surgery_templates
+  '004_surgery_templates': m_004_surgery_templates,
+  '005_backup_settings': m_005_backup_settings
 }

--- a/src/main/db/migrations/005_backup_settings.ts
+++ b/src/main/db/migrations/005_backup_settings.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Insert backup settings
+  await db
+    .insertInto('app_settings')
+    .values([
+      { key: 'backup_enabled', value: 'true', display_name: 'Backup Enabled' },
+      { key: 'backup_folder', value: null, display_name: 'Backup Folder' },
+      { key: 'last_backup_time', value: null, display_name: 'Last Backup Time' }
+    ])
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .deleteFrom('app_settings')
+    .where('key', 'in', ['backup_enabled', 'backup_folder', 'last_backup_time'])
+    .execute()
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain } from 'electron'
 import electronUpdater, { type AppUpdater, type UpdateInfo } from 'electron-updater'
+import { createBackup } from './backup'
 
 export type UpdateStatus =
   | 'idle'
@@ -97,9 +98,15 @@ export function registerUpdaterIpcHandlers(): void {
     await autoUpdater.downloadUpdate()
   })
 
-  ipcMain.handle('quitAndInstall', () => {
+  ipcMain.handle('quitAndInstall', async () => {
     if (!autoUpdater) {
       throw new Error('Auto updater not initialized')
+    }
+    // Always backup before update
+    try {
+      await createBackup('pre-update')
+    } catch (e) {
+      console.error('Pre-update backup failed:', e)
     }
     autoUpdater.quitAndInstall()
   })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -11,6 +11,18 @@ type ElectronApi = ElectronAPI & {
   downloadUpdate: () => Promise<void>
   quitAndInstall: () => Promise<void>
   onUpdateStatus: (callback: (payload: UpdateStatusPayload) => void) => () => void
+  selectBackupFolder: () => Promise<string | null>
+  selectBackupFile: () => Promise<string | null>
+  saveBackupAs: (
+    sourcePath?: string,
+    defaultFilename?: string
+  ) => Promise<{
+    success: boolean
+    path?: string
+    canceled?: boolean
+    error?: string
+  }>
+  restartApp: () => Promise<void>
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,30 @@ const onUpdateStatus = (callback: (payload: UpdateStatusPayload) => void) => {
   }
 }
 
+const selectBackupFolder = async (): Promise<string | null> => {
+  return await ipcRenderer.invoke('selectBackupFolder')
+}
+
+const selectBackupFile = async (): Promise<string | null> => {
+  return await ipcRenderer.invoke('selectBackupFile')
+}
+
+const saveBackupAs = async (
+  sourcePath?: string,
+  defaultFilename?: string
+): Promise<{
+  success: boolean
+  path?: string
+  canceled?: boolean
+  error?: string
+}> => {
+  return await ipcRenderer.invoke('saveBackupAs', sourcePath, defaultFilename)
+}
+
+const restartApp = async (): Promise<void> => {
+  return await ipcRenderer.invoke('restartApp')
+}
+
 const electronApi = {
   ...electronAPI,
   getAppVersion,
@@ -58,7 +82,11 @@ const electronApi = {
   checkForUpdates,
   downloadUpdate,
   quitAndInstall,
-  onUpdateStatus
+  onUpdateStatus,
+  selectBackupFolder,
+  selectBackupFile,
+  saveBackupAs,
+  restartApp
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/components/settings/BackupSettings.tsx
+++ b/src/renderer/src/components/settings/BackupSettings.tsx
@@ -1,0 +1,450 @@
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Save,
+  FolderOpen,
+  Trash2,
+  Clock,
+  HardDrive,
+  Download,
+  RotateCcw,
+  Upload
+} from 'lucide-react'
+import toast from 'react-hot-toast'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { Label } from '@renderer/components/ui/label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@renderer/components/ui/table'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@renderer/components/ui/alert-dialog'
+import { queries } from '@renderer/lib/queries'
+import { useSettings } from '@renderer/contexts/SettingsContext'
+import { unwrapResult } from '@renderer/lib/utils'
+import { BackupInfo } from 'src/shared/types/backup'
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 Bytes'
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+function formatTimestamp(timestamp: string): string {
+  try {
+    const date = new Date(timestamp.replace(/_/g, 'T').replace(/-(\d{2})-(\d{2})$/, ':$1:$2'))
+    return date.toLocaleString()
+  } catch {
+    return timestamp
+  }
+}
+
+export const BackupSettings = () => {
+  const queryClient = useQueryClient()
+  const { settings } = useSettings()
+
+  const [backupEnabled, setBackupEnabled] = useState(true)
+  const [backupFolder, setBackupFolder] = useState<string>('')
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [backupToDelete, setBackupToDelete] = useState<BackupInfo | null>(null)
+  const [restoreDialogOpen, setRestoreDialogOpen] = useState(false)
+  const [backupToRestore, setBackupToRestore] = useState<BackupInfo | null>(null)
+  const [externalRestoreDialogOpen, setExternalRestoreDialogOpen] = useState(false)
+  const [externalFilePath, setExternalFilePath] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (settings) {
+      setBackupEnabled(settings['backup_enabled'] === 'true')
+      setBackupFolder(settings['backup_folder'] || '')
+    }
+  }, [settings])
+
+  const { data: backups, isLoading: isLoadingBackups } = useQuery({
+    ...queries.backup.list
+  })
+
+  const lastBackupTime = settings?.['last_backup_time']
+
+  const createBackupMutation = useMutation({
+    mutationFn: async () => {
+      return unwrapResult(window.api.invoke('createBackup', 'manual'))
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.backup.list)
+      await queryClient.invalidateQueries(queries.app.settings)
+      toast.success('Backup created successfully')
+    },
+    onError: (error: Error) => {
+      toast.error(`Backup failed: ${error.message}`)
+    }
+  })
+
+  const deleteBackupMutation = useMutation({
+    mutationFn: async (filename: string) => {
+      return unwrapResult(window.api.invoke('deleteBackup', filename))
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.backup.list)
+      toast.success('Backup deleted')
+      setDeleteDialogOpen(false)
+      setBackupToDelete(null)
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    }
+  })
+
+  const restoreBackupMutation = useMutation({
+    mutationFn: async (backupPath: string) => {
+      return unwrapResult(window.api.invoke('restoreBackup', backupPath))
+    },
+    onSuccess: async () => {
+      toast.success('Database restored successfully. Restarting app...')
+      setRestoreDialogOpen(false)
+      setBackupToRestore(null)
+      // Wait a moment for the toast to be visible, then restart
+      setTimeout(() => {
+        window.electronApi.restartApp()
+      }, 1000)
+    },
+    onError: (error: Error) => {
+      toast.error(`Restore failed: ${error.message}`)
+    }
+  })
+
+  const updateSettingsMutation = useMutation({
+    mutationFn: async (data: { key: string; value: string | null }[]) => {
+      await window.api.invoke('updateSettings', data)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.app.settings)
+      toast.success('Backup settings saved')
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    }
+  })
+
+  const handleDownloadBackup = async (backup: BackupInfo) => {
+    try {
+      const result = await window.electronApi.saveBackupAs(backup.path, backup.filename)
+      if (result.canceled) {
+        // User cancelled, do nothing
+      } else if (result.success) {
+        toast.success('Backup downloaded successfully')
+      } else {
+        toast.error(`Failed to download backup: ${result.error}`)
+      }
+    } catch (error) {
+      toast.error(
+        `Failed to download backup: ${error instanceof Error ? error.message : 'Unknown error'}`
+      )
+    }
+  }
+
+  const handleSelectFolder = async () => {
+    const folder = await window.electronApi.selectBackupFolder()
+    if (folder) {
+      setBackupFolder(folder)
+    }
+  }
+
+  const handleSaveSettings = async () => {
+    await updateSettingsMutation.mutateAsync([
+      { key: 'backup_enabled', value: backupEnabled ? 'true' : 'false' },
+      { key: 'backup_folder', value: backupFolder || null }
+    ])
+  }
+
+  const handleDeleteBackup = (backup: BackupInfo) => {
+    setBackupToDelete(backup)
+    setDeleteDialogOpen(true)
+  }
+
+  const confirmDelete = () => {
+    if (backupToDelete) {
+      deleteBackupMutation.mutate(backupToDelete.filename)
+    }
+  }
+
+  const handleRestoreBackup = (backup: BackupInfo) => {
+    setBackupToRestore(backup)
+    setRestoreDialogOpen(true)
+  }
+
+  const confirmRestore = () => {
+    if (backupToRestore) {
+      restoreBackupMutation.mutate(backupToRestore.path)
+    }
+  }
+
+  const handleRestoreFromFile = async () => {
+    const filePath = await window.electronApi.selectBackupFile()
+    if (filePath) {
+      setExternalFilePath(filePath)
+      setExternalRestoreDialogOpen(true)
+    }
+  }
+
+  const confirmExternalRestore = () => {
+    if (externalFilePath) {
+      restoreBackupMutation.mutate(externalFilePath)
+      setExternalRestoreDialogOpen(false)
+      setExternalFilePath(null)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <h2 className="text-xl font-bold">Backup</h2>
+
+      {/* Automatic Backups Section */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-medium">Automatic Backups</h3>
+          <p className="text-sm text-muted-foreground">
+            Configure automatic backup schedule and storage location
+          </p>
+        </div>
+
+        <div className="rounded-lg border p-4 space-y-4">
+          <div className="flex items-center space-x-3">
+            <input
+              type="checkbox"
+              id="backup-enabled"
+              checked={backupEnabled}
+              onChange={(e) => setBackupEnabled(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+            />
+            <Label htmlFor="backup-enabled" className="cursor-pointer">
+              Enable hourly automatic backups
+            </Label>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Backup Folder</Label>
+            <div className="flex gap-2">
+              <Input
+                value={backupFolder}
+                onChange={(e) => setBackupFolder(e.target.value)}
+                placeholder="Default: ~/.opnotes/backups/"
+                className="flex-1"
+              />
+              <Button variant="outline" onClick={handleSelectFolder}>
+                <FolderOpen className="h-4 w-4 mr-2" />
+                Browse
+              </Button>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Leave empty to use the default backup location
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between pt-2">
+            <Button
+              onClick={handleSaveSettings}
+              leftIcon={<Save className="h-4 w-4" />}
+              isLoading={updateSettingsMutation.isPending}
+              loadingText="Saving..."
+            >
+              Save Settings
+            </Button>
+            {lastBackupTime && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Clock className="h-4 w-4" />
+                Last backup: {new Date(lastBackupTime).toLocaleString()}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Quick Actions Section */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-medium">Quick Actions</h3>
+          <p className="text-sm text-muted-foreground">Create a backup or restore from a file</p>
+        </div>
+
+        <div className="rounded-lg border p-4">
+          <div className="flex gap-3 flex-wrap">
+            <Button
+              variant="outline"
+              onClick={() => createBackupMutation.mutate()}
+              leftIcon={<HardDrive className="h-4 w-4" />}
+              isLoading={createBackupMutation.isPending}
+              loadingText="Creating..."
+            >
+              Backup Now
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleRestoreFromFile}
+              leftIcon={<Upload className="h-4 w-4" />}
+            >
+              Restore from File
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Recent Backups Section */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-medium">Recent Backups</h3>
+          <p className="text-sm text-muted-foreground">
+            Up to 10 backups are kept. Older backups are automatically deleted.
+          </p>
+        </div>
+
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Filename</TableHead>
+                <TableHead>Date</TableHead>
+                <TableHead>Size</TableHead>
+                <TableHead className="w-[80px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoadingBackups ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center py-8">
+                    Loading...
+                  </TableCell>
+                </TableRow>
+              ) : !backups || backups.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center py-8 text-muted-foreground">
+                    No backups found. Click &quot;Backup Now&quot; to create one.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                backups.map((backup: BackupInfo) => (
+                  <TableRow key={backup.filename}>
+                    <TableCell className="font-mono text-sm">{backup.filename}</TableCell>
+                    <TableCell>{formatTimestamp(backup.timestamp)}</TableCell>
+                    <TableCell>{formatBytes(backup.size)}</TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRestoreBackup(backup)}
+                          title="Restore this backup"
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDownloadBackup(backup)}
+                          title="Download backup"
+                        >
+                          <Download className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDeleteBackup(backup)}
+                          title="Delete backup"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Backup</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &quot;{backupToDelete?.filename}&quot;? This action
+              cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button
+                variant="destructive"
+                onClick={confirmDelete}
+                isLoading={deleteBackupMutation.isPending}
+              >
+                Delete
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={restoreDialogOpen} onOpenChange={setRestoreDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore Backup</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to restore &quot;{backupToRestore?.filename}&quot;? This will
+              replace the current database with this backup. A safety backup of your current data
+              will be created first. The app will restart after the restore.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button onClick={confirmRestore} isLoading={restoreBackupMutation.isPending}>
+                Restore
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={externalRestoreDialogOpen} onOpenChange={setExternalRestoreDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore from External File</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to restore from this file? This will replace the current
+              database with the selected backup. A safety backup of your current data will be
+              created first. The app will restart after the restore.
+              <br />
+              <br />
+              <span className="font-mono text-xs break-all">{externalFilePath}</span>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button onClick={confirmExternalRestore} isLoading={restoreBackupMutation.isPending}>
+                Restore
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/renderer/src/lib/queries.ts
+++ b/src/renderer/src/lib/queries.ts
@@ -78,5 +78,11 @@ export const queries = createQueryKeyStore({
       queryKey: null,
       queryFn: () => unwrapResult(window.api.invoke('getTemplateTags'))
     }
+  },
+  backup: {
+    list: {
+      queryKey: null,
+      queryFn: () => unwrapResult(window.api.invoke('listBackups'))
+    }
   }
 })

--- a/src/renderer/src/routes/settings/settings-index.tsx
+++ b/src/renderer/src/routes/settings/settings-index.tsx
@@ -2,13 +2,14 @@ import { useBreadcrumbs } from '@renderer/contexts/BreadcrumbContext'
 import { AppLayout } from '@renderer/layouts/AppLayout'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { Settings, FileText } from 'lucide-react'
+import { Settings, FileText, HardDrive } from 'lucide-react'
 import { cn } from '@renderer/lib/utils'
 import { GeneralSettings } from '@renderer/components/settings/GeneralSettings'
 import { TemplatesSettings } from '@renderer/components/settings/TemplatesSettings'
+import { BackupSettings } from '@renderer/components/settings/BackupSettings'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@renderer/components/ui/tabs'
 
-type SettingsSection = 'general' | 'templates'
+type SettingsSection = 'general' | 'templates' | 'backup'
 
 interface NavItemProps {
   icon: React.ReactNode
@@ -37,7 +38,8 @@ export const SettingsIndex = () => {
   const { setBreadcrumbs } = useBreadcrumbs()
 
   const tabParam = searchParams.get('tab')
-  const activeSection: SettingsSection = tabParam === 'templates' ? 'templates' : 'general'
+  const activeSection: SettingsSection =
+    tabParam === 'templates' ? 'templates' : tabParam === 'backup' ? 'backup' : 'general'
 
   const setActiveSection = (section: SettingsSection) => {
     setSearchParams(section === 'general' ? {} : { tab: section })
@@ -65,11 +67,18 @@ export const SettingsIndex = () => {
               isActive={activeSection === 'templates'}
               onClick={() => setActiveSection('templates')}
             />
+            <NavItem
+              icon={<HardDrive className="h-4 w-4" />}
+              label="Backup"
+              isActive={activeSection === 'backup'}
+              onClick={() => setActiveSection('backup')}
+            />
           </div>
         </nav>
         <div className="flex-1 min-w-0">
           {activeSection === 'general' && <GeneralSettings />}
           {activeSection === 'templates' && <TemplatesSettings />}
+          {activeSection === 'backup' && <BackupSettings />}
         </div>
       </div>
 
@@ -88,12 +97,19 @@ export const SettingsIndex = () => {
               <FileText className="h-4 w-4 mr-2" />
               Templates
             </TabsTrigger>
+            <TabsTrigger value="backup" className="flex-1">
+              <HardDrive className="h-4 w-4 mr-2" />
+              Backup
+            </TabsTrigger>
           </TabsList>
           <TabsContent value="general">
             <GeneralSettings />
           </TabsContent>
           <TabsContent value="templates">
             <TemplatesSettings />
+          </TabsContent>
+          <TabsContent value="backup">
+            <BackupSettings />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/shared/types/backup.d.ts
+++ b/src/shared/types/backup.d.ts
@@ -1,0 +1,20 @@
+export type BackupReason = 'manual' | 'scheduled' | 'pre-update'
+
+export interface BackupInfo {
+  filename: string
+  path: string
+  timestamp: string
+  size: number
+}
+
+export interface BackupResult {
+  success: boolean
+  path?: string
+  error?: string
+}
+
+export interface BackupSettings {
+  backup_enabled: boolean
+  backup_folder: string | null
+  last_backup_time: string | null
+}


### PR DESCRIPTION
## Summary
- Add automatic hourly backups with configurable storage location
- Add manual backup creation and backup file management  
- Add restore functionality from listed backups and external files
- Create safety backup before restore and restart app after restore
- Organize backup settings UI into clear sections (Automatic Backups, Quick Actions, Recent Backups)

## Features
- **Automatic Backups**: Enable/disable hourly backups, configure backup folder
- **Manual Backup**: Create backup on demand with "Backup Now" button
- **Restore from List**: Restore any backup from the recent backups table
- **Restore from File**: Import and restore from an external .db backup file
- **Safety Backup**: Automatically creates a safety backup before any restore operation
- **App Restart**: App automatically restarts after restore to reload the database

## Test plan
- [ ] Enable automatic backups and verify they run hourly
- [ ] Create manual backup and verify it appears in the list
- [ ] Download a backup file and verify it saves correctly
- [ ] Delete a backup and verify it's removed
- [ ] Restore from a backup in the list and verify data is restored after app restart
- [ ] Restore from an external backup file and verify data is restored
- [ ] Verify safety backup is created before restore (check for `data_pre_restore_*.db` files)