### PR TITLE
feat: add onboarding wizard for first-time setup

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -4,6 +4,7 @@ import * as m_002_telephone_setting from './migrations/002_telephone_setting'
 import * as m_003_doa_dod from './migrations/003_doa_dod'
 import * as m_004_surgery_templates from './migrations/004_surgery_templates'
 import * as m_005_backup_settings from './migrations/005_backup_settings'
+import * as m_006_onboarding_setting from './migrations/006_onboarding_setting'
 
 export default {
   '000_init': m_000_init,
@@ -11,5 +12,6 @@ export default {
   '002_telephone_setting': m_002_telephone_setting,
   '003_doa_dod': m_003_doa_dod,
   '004_surgery_templates': m_004_surgery_templates,
-  '005_backup_settings': m_005_backup_settings
+  '005_backup_settings': m_005_backup_settings,
+  '006_onboarding_setting': m_006_onboarding_setting
 }

--- a/src/main/db/migrations/006_onboarding_setting.ts
+++ b/src/main/db/migrations/006_onboarding_setting.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Check if hospital AND unit are already configured
+  const hospitalSetting = await db
+    .selectFrom('app_settings')
+    .select('value')
+    .where('key', '=', 'hospital')
+    .executeTakeFirst()
+
+  const unitSetting = await db
+    .selectFrom('app_settings')
+    .select('value')
+    .where('key', '=', 'unit')
+    .executeTakeFirst()
+
+  // If both are set, mark onboarding as complete (existing configured user)
+  const isAlreadyConfigured = hospitalSetting?.value && unitSetting?.value
+
+  await db
+    .insertInto('app_settings')
+    .values({
+      key: 'onboarding_completed',
+      value: isAlreadyConfigured ? 'true' : null,
+      display_name: 'Onboarding Completed'
+    })
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.deleteFrom('app_settings').where('key', '=', 'onboarding_completed').execute()
+}

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,162 @@
+import { useState, useRef } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Progress } from '@renderer/components/ui/progress'
+import { ChevronLeft, ChevronRight, X, Check } from 'lucide-react'
+import { WelcomeStep } from './steps/WelcomeStep'
+import { HospitalInfoStep, HospitalInfoStepRef } from './steps/HospitalInfoStep'
+import { TemplatesStep } from './steps/TemplatesStep'
+import { QuickTipsStep } from './steps/QuickTipsStep'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { queries } from '@renderer/lib/queries'
+import { cn } from '@renderer/lib/utils'
+
+const STEPS = [
+  { id: 'welcome', title: 'Welcome' },
+  { id: 'hospital', title: 'Hospital Info' },
+  { id: 'templates', title: 'Templates' },
+  { id: 'tips', title: 'Quick Tips' }
+] as const
+
+interface OnboardingWizardProps {
+  onComplete: () => void
+}
+
+export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
+  const [currentStep, setCurrentStep] = useState(0)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const hospitalInfoRef = useRef<HospitalInfoStepRef>(null)
+  const queryClient = useQueryClient()
+
+  const completeOnboardingMutation = useMutation({
+    mutationFn: async () => {
+      await window.api.invoke('updateSettings', [{ key: 'onboarding_completed', value: 'true' }])
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.app.settings)
+      onComplete()
+    }
+  })
+
+  const progress = ((currentStep + 1) / STEPS.length) * 100
+
+  const handleNext = async () => {
+    // If on hospital step, validate and save first
+    if (currentStep === 1 && hospitalInfoRef.current) {
+      setIsSubmitting(true)
+      const success = await hospitalInfoRef.current.submit()
+      setIsSubmitting(false)
+      if (!success) {
+        return
+      }
+    }
+
+    if (currentStep < STEPS.length - 1) {
+      setCurrentStep(currentStep + 1)
+    } else {
+      // Last step - complete onboarding
+      completeOnboardingMutation.mutate()
+    }
+  }
+
+  const handleBack = () => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1)
+    }
+  }
+
+  const handleSkip = () => {
+    completeOnboardingMutation.mutate()
+  }
+
+  const isLastStep = currentStep === STEPS.length - 1
+  const isFirstStep = currentStep === 0
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 0:
+        return <WelcomeStep />
+      case 1:
+        return <HospitalInfoStep ref={hospitalInfoRef} />
+      case 2:
+        return <TemplatesStep />
+      case 3:
+        return <QuickTipsStep />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-background flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b">
+        <div className="flex items-center gap-4">
+          <span className="text-sm font-medium text-muted-foreground">
+            Step {currentStep + 1} of {STEPS.length}
+          </span>
+          <div className="flex gap-1">
+            {STEPS.map((step, index) => (
+              <div
+                key={step.id}
+                className={cn(
+                  'text-xs px-2 py-1 rounded-full',
+                  index === currentStep
+                    ? 'bg-primary text-primary-foreground'
+                    : index < currentStep
+                      ? 'bg-primary/20 text-primary'
+                      : 'bg-muted text-muted-foreground'
+                )}
+              >
+                {step.title}
+              </div>
+            ))}
+          </div>
+        </div>
+        <Button variant="ghost" size="sm" onClick={handleSkip} className="text-muted-foreground">
+          <X className="w-4 h-4 mr-1" />
+          Skip Setup
+        </Button>
+      </div>
+
+      {/* Progress bar */}
+      <Progress value={progress} className="h-1 rounded-none" />
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl mx-auto p-8">{renderStep()}</div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between p-4 border-t bg-muted/50">
+        <Button
+          variant="outline"
+          onClick={handleBack}
+          disabled={isFirstStep}
+          className={cn(isFirstStep && 'invisible')}
+        >
+          <ChevronLeft className="w-4 h-4 mr-1" />
+          Back
+        </Button>
+
+        <Button
+          onClick={handleNext}
+          disabled={isSubmitting || completeOnboardingMutation.isPending}
+          isLoading={isSubmitting || completeOnboardingMutation.isPending}
+          loadingText={isLastStep ? 'Finishing...' : 'Saving...'}
+        >
+          {isLastStep ? (
+            <>
+              <Check className="w-4 h-4 mr-1" />
+              Get Started
+            </>
+          ) : (
+            <>
+              Next
+              <ChevronRight className="w-4 h-4 ml-1" />
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/onboarding/steps/HospitalInfoStep.tsx
+++ b/src/renderer/src/components/onboarding/steps/HospitalInfoStep.tsx
@@ -1,0 +1,144 @@
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@renderer/components/ui/form'
+import { Input } from '@renderer/components/ui/input'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useSettings } from '@renderer/contexts/SettingsContext'
+import { useEffect, useImperativeHandle, forwardRef } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { queries } from '@renderer/lib/queries'
+import { Building2 } from 'lucide-react'
+
+const formSchema = z.object({
+  hospital: z.string().min(1, 'Hospital name is required'),
+  unit: z.string().min(1, 'Unit name is required'),
+  telephone: z.string()
+})
+
+type FormSchema = z.infer<typeof formSchema>
+
+export interface HospitalInfoStepRef {
+  submit: () => Promise<boolean>
+}
+
+export const HospitalInfoStep = forwardRef<HospitalInfoStepRef>((_, ref) => {
+  const queryClient = useQueryClient()
+  const { settings } = useSettings()
+
+  const form = useForm<FormSchema>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      hospital: '',
+      unit: '',
+      telephone: ''
+    }
+  })
+
+  useEffect(() => {
+    if (settings) {
+      form.reset({
+        hospital: settings['hospital'] || '',
+        unit: settings['unit'] || '',
+        telephone: settings['telephone'] || ''
+      })
+    }
+  }, [form, settings])
+
+  const updateSettingsMutation = useMutation({
+    mutationFn: async (data: FormSchema) => {
+      const updatePayload = Object.entries(data).map(([key, value]) => ({
+        key,
+        value
+      }))
+      await window.api.invoke('updateSettings', updatePayload)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.app.settings)
+    }
+  })
+
+  useImperativeHandle(ref, () => ({
+    submit: async () => {
+      const isValid = await form.trigger()
+      if (!isValid) {
+        return false
+      }
+      const data = form.getValues()
+      await updateSettingsMutation.mutateAsync(data)
+      return true
+    }
+  }))
+
+  return (
+    <div className="flex flex-col items-center space-y-6">
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-primary/10">
+        <Building2 className="w-8 h-8 text-primary" />
+      </div>
+      <div className="text-center space-y-2">
+        <h2 className="text-2xl font-bold">Hospital Information</h2>
+        <p className="text-muted-foreground">
+          Enter your hospital details. This information will appear on printed documents.
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form className="w-full max-w-md space-y-4">
+          <FormField
+            name="hospital"
+            control={form.control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Hospital Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Enter hospital name" {...field} />
+                </FormControl>
+                <FormDescription>
+                  The name of your hospital (e.g., General Hospital Colombo)
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            name="unit"
+            control={form.control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Unit Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Enter unit name" {...field} />
+                </FormControl>
+                <FormDescription>Your department or unit (e.g., Surgical Unit A)</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            name="telephone"
+            control={form.control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Contact Telephone</FormLabel>
+                <FormControl>
+                  <Input placeholder="Enter telephone number" {...field} />
+                </FormControl>
+                <FormDescription>Contact number for the unit (optional)</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+    </div>
+  )
+})
+
+HospitalInfoStep.displayName = 'HospitalInfoStep'

--- a/src/renderer/src/components/onboarding/steps/QuickTipsStep.tsx
+++ b/src/renderer/src/components/onboarding/steps/QuickTipsStep.tsx
@@ -1,0 +1,86 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@renderer/components/ui/card'
+import { Search, Printer, Users, CalendarCheck, Sparkles } from 'lucide-react'
+
+export const QuickTipsStep = () => {
+  return (
+    <div className="flex flex-col items-center space-y-6">
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-primary/10">
+        <Sparkles className="w-8 h-8 text-primary" />
+      </div>
+      <div className="text-center space-y-2">
+        <h2 className="text-2xl font-bold">Quick Tips</h2>
+        <p className="text-muted-foreground max-w-md">
+          Here are some helpful features to get you started.
+        </p>
+      </div>
+
+      <div className="grid gap-3 w-full max-w-lg">
+        <Card>
+          <CardHeader className="py-3 pb-1">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Search className="w-4 h-4 text-primary" />
+              Powerful Search
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="py-2">
+            <CardDescription>
+              Quickly find patients and surgeries using full-text search. Search by name, BHT
+              number, diagnosis, or procedure.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3 pb-1">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Printer className="w-4 h-4 text-primary" />
+              Print Documents
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="py-2">
+            <CardDescription>
+              Print surgery notes, patient records, and follow-up summaries. Your hospital details
+              are automatically included.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3 pb-1">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Users className="w-4 h-4 text-primary" />
+              Doctor Management
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="py-2">
+            <CardDescription>
+              Maintain a database of doctors. Assign surgeons and assistants to each surgery for
+              complete records.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3 pb-1">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <CalendarCheck className="w-4 h-4 text-primary" />
+              Follow-up Tracking
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="py-2">
+            <CardDescription>
+              Record follow-up visits and track patient progress after surgery. Never lose track of
+              post-operative care.
+            </CardDescription>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/onboarding/steps/TemplatesStep.tsx
+++ b/src/renderer/src/components/onboarding/steps/TemplatesStep.tsx
@@ -1,0 +1,60 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@renderer/components/ui/card'
+import { FileText, Copy, Clock } from 'lucide-react'
+
+export const TemplatesStep = () => {
+  return (
+    <div className="flex flex-col items-center space-y-6">
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-primary/10">
+        <FileText className="w-8 h-8 text-primary" />
+      </div>
+      <div className="text-center space-y-2">
+        <h2 className="text-2xl font-bold">Surgery Templates</h2>
+        <p className="text-muted-foreground max-w-md">
+          Save time by creating reusable templates for common surgical procedures.
+        </p>
+      </div>
+
+      <div className="grid gap-4 w-full max-w-lg">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Copy className="w-4 h-4" />
+              Create Once, Use Many Times
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Define standard procedures, pre-op preparations, and post-op instructions once. Apply
+              them to new surgeries with a single click.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Clock className="w-4 h-4" />
+              Reduce Documentation Time
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Stop retyping the same information. Templates auto-fill surgery notes, letting you
+              focus on patient-specific details.
+            </CardDescription>
+          </CardContent>
+        </Card>
+      </div>
+
+      <p className="text-sm text-muted-foreground text-center max-w-md">
+        You can create and manage templates from Settings → Templates after completing setup.
+      </p>
+    </div>
+  )
+}

--- a/src/renderer/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/src/renderer/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,17 @@
+import hero from '@renderer/assets/hero.svg?asset'
+
+export const WelcomeStep = () => {
+  return (
+    <div className="flex flex-col items-center justify-center text-center space-y-6">
+      <img src={hero} alt="Op Notes" className="w-48 h-48" />
+      <h1 className="text-4xl font-bold">Welcome to Op Notes</h1>
+      <p className="text-lg text-muted-foreground max-w-md">
+        A surgical notes management application designed to help you efficiently manage patient
+        records, surgery notes, and follow-up care.
+      </p>
+      <div className="text-sm text-muted-foreground">
+        Let&apos;s get started by setting up your hospital information.
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/GeneralSettings.tsx
@@ -9,7 +9,7 @@ import {
 } from '@renderer/components/ui/form'
 import { Input } from '@renderer/components/ui/input'
 import { Button } from '@renderer/components/ui/button'
-import { Save } from 'lucide-react'
+import { Save, RotateCcw } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -63,6 +63,15 @@ export const GeneralSettings = () => {
     },
     onError: (error: Error) => {
       toast.error(error.message)
+    }
+  })
+
+  const resetOnboardingMutation = useMutation({
+    mutationFn: async () => {
+      await window.api.invoke('updateSettings', [{ key: 'onboarding_completed', value: null }])
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.app.settings)
     }
   })
 
@@ -137,6 +146,22 @@ export const GeneralSettings = () => {
           </Button>
         </div>
       </Form>
+
+      <div className="mt-8 pt-6 border-t">
+        <h3 className="text-lg font-semibold mb-2">Setup Wizard</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Re-run the setup wizard to update your hospital information and review the app features.
+        </p>
+        <Button
+          variant="outline"
+          leftIcon={<RotateCcw className="w-4 h-4" />}
+          onClick={() => resetOnboardingMutation.mutate()}
+          isLoading={resetOnboardingMutation.isPending}
+          loadingText="Resetting..."
+        >
+          Run Setup Wizard
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/routes/root.tsx
+++ b/src/renderer/src/routes/root.tsx
@@ -12,6 +12,7 @@ import { UpdateProvider } from '@renderer/contexts/UpdateContext'
 import { UpdateIndicator } from '@renderer/components/update/UpdateIndicator'
 import { PoweredBy } from '@renderer/components/brand/PowredBy'
 import { MadeWithLove } from '@renderer/components/brand/MadeWithLove'
+import { OnboardingWizard } from '@renderer/components/onboarding/OnboardingWizard'
 
 const NavLinkComponent = ({
   to,
@@ -71,10 +72,31 @@ const SplashScreen = ({ error }: { error?: string }) => {
   )
 }
 
+const OnboardingGate = ({ children }: { children: React.ReactNode }) => {
+  const { settings } = useSettings()
+
+  // Wait for settings to load
+  const settingsLoaded = Object.keys(settings).length > 0
+  if (!settingsLoaded) {
+    return null
+  }
+
+  // Show wizard if onboarding not completed
+  const showOnboarding = settings['onboarding_completed'] !== 'true'
+
+  if (showOnboarding) {
+    return <OnboardingWizard onComplete={() => {}} />
+  }
+
+  return <>{children}</>
+}
+
 const Providers = ({ children }) => {
   return (
     <SettingsProvider>
-      <UpdateProvider>{children}</UpdateProvider>
+      <UpdateProvider>
+        <OnboardingGate>{children}</OnboardingGate>
+      </UpdateProvider>
     </SettingsProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Add 4-step onboarding wizard that appears on first app launch
- Collect hospital information (name, unit, telephone) during setup
- Introduce users to templates and quick tips about app features
- Allow users to skip setup and re-run later from Settings > General

## Changes
- New migration `006_onboarding_setting.ts` with smart initialization for existing users
- New `OnboardingWizard` component with step navigation and progress bar
- Step components: Welcome, Hospital Info, Templates intro, Quick Tips
- Modified `root.tsx` to add `OnboardingGate` wrapper
- Added "Run Setup Wizard" button in General Settings

## Test plan
- [ ] Fresh install: Delete `~/.opnotes/data.db`, restart app → wizard should appear
- [ ] Existing configured user: User has hospital+unit set → wizard should NOT appear
- [ ] Skip test: Click "Skip Setup" → wizard closes, app loads
- [ ] Complete test: Fill hospital info, complete all steps → settings saved
- [ ] Re-run test: Settings > General > "Run Setup Wizard" → wizard appears again
- [ ] Persistence test: Complete wizard, restart app → wizard should NOT appear