### PR TITLE
feat: add Support section with community and documentation pages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug Report
+description: Report a bug or issue with Op Notes
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us understand and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: What should have happened instead?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: App Version
+      description: Which version of Op Notes are you using? (Check Settings > General or the sidebar)
+      placeholder: "e.g., 0.0.11"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS (Intel)
+        - macOS (Apple Silicon)
+        - Ubuntu/Debian Linux
+        - Other Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem. You can paste images directly here.
+      placeholder: Drag and drop or paste screenshots here...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+      placeholder: Any other information that might help us understand the issue...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: WhatsApp Community
+    url: https://chat.whatsapp.com/YOUR_INVITE_LINK
+    about: Join our WhatsApp community for quick support and discussions
+  - name: GitHub Discussions
+    url: https://github.com/wavezync/opnotes/discussions
+    about: Ask questions, share ideas, or discuss features with the community
+  - name: Documentation
+    url: https://github.com/wavezync/opnotes/wiki
+    about: Read the documentation and guides

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature Request
+description: Suggest a new feature for Op Notes
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a feature! Your ideas help make Op Notes better for healthcare professionals worldwide.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Need
+      description: What problem are you trying to solve? What workflow challenge does this address?
+      placeholder: |
+        I'm frustrated when...
+        It would be helpful if...
+        Currently I have to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like. How would this feature work?
+      placeholder: |
+        I would like to see...
+        It could work by...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Who Would Benefit?
+      description: How many people do you think would benefit from this feature?
+      options:
+        - Just me
+        - My team/unit
+        - Multiple departments
+        - The entire hospital
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority for Your Workflow
+      description: How important is this feature for your daily work?
+      options:
+        - Nice to have
+        - Would improve my workflow
+        - Would significantly help my work
+        - Critical for my workflow
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: Describe any alternative solutions you've thought of...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or examples about the feature request here.
+      placeholder: Any other information, mockups, or examples...

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   Stethoscope,
   UserCog,
   ScrollText,
+  HeartHandshake,
   Settings
 } from 'lucide-react'
 import opNotesLogo from '@renderer/assets/opnotes-logo.png'
@@ -103,12 +104,18 @@ export function Sidebar() {
       </nav>
 
       {/* Bottom section */}
-      <div className="flex flex-col items-center py-4 px-2 border-t border-sidebar-border">
+      <div className="flex flex-col items-center py-4 px-2 border-t border-sidebar-border gap-1">
+        <NavItem
+          to="/support"
+          icon={<HeartHandshake className="h-5 w-5" />}
+          label="Support"
+          index={mainNavItems.length}
+        />
         <NavItem
           to="/settings"
           icon={<Settings className="h-5 w-5" />}
           label="Settings"
-          index={mainNavItems.length}
+          index={mainNavItems.length + 1}
         />
       </div>
 

--- a/src/renderer/src/components/support/AboutWaveZync.tsx
+++ b/src/renderer/src/components/support/AboutWaveZync.tsx
@@ -1,0 +1,164 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@renderer/components/ui/card'
+import { Button } from '@renderer/components/ui/button'
+import {
+  Stethoscope,
+  Users,
+  Shield,
+  Code,
+  ExternalLink,
+  FileText,
+  Printer,
+  FolderSearch
+} from 'lucide-react'
+import opNotesLogo from '@renderer/assets/opnotes-logo.png'
+import wavezyncLogoDark from '../../../../../resources/wavezync-dark.png?asset'
+import wavezyncLogoLight from '../../../../../resources/wavezync-light.png?asset'
+import { useTheme } from '@renderer/contexts/ThemeContext'
+import { useSettings } from '@renderer/contexts/SettingsContext'
+
+export const AboutWaveZync = () => {
+  const { theme } = useTheme()
+  const { appVersion } = useSettings()
+  const wavezyncLogo = theme.mode === 'light' ? wavezyncLogoLight : wavezyncLogoDark
+
+  const features = [
+    {
+      icon: <Stethoscope className="h-5 w-5" />,
+      title: 'Surgery Management',
+      description: 'Create detailed surgical notes with procedures, findings, and follow-ups.',
+      color: 'rose'
+    },
+    {
+      icon: <Users className="h-5 w-5" />,
+      title: 'Patient Records',
+      description: 'Organize patient information with BHT numbers, demographics, and history.',
+      color: 'blue'
+    },
+    {
+      icon: <FileText className="h-5 w-5" />,
+      title: 'Templates',
+      description: 'Save time with reusable templates for common surgical procedures.',
+      color: 'amber'
+    },
+    {
+      icon: <Printer className="h-5 w-5" />,
+      title: 'Print Reports',
+      description: 'Generate professional BHT reports ready for patient files.',
+      color: 'violet'
+    },
+    {
+      icon: <FolderSearch className="h-5 w-5" />,
+      title: 'Quick Search',
+      description: 'Find any patient or surgery instantly with full-text search.',
+      color: 'emerald'
+    },
+    {
+      icon: <Shield className="h-5 w-5" />,
+      title: 'Privacy First',
+      description: 'All data stays on your computer. No cloud, no tracking.',
+      color: 'slate'
+    }
+  ]
+
+  const getColorClasses = (color: string) => {
+    const colors: Record<string, { bg: string; text: string }> = {
+      rose: { bg: 'bg-rose-500/10', text: 'text-rose-500' },
+      blue: { bg: 'bg-blue-500/10', text: 'text-blue-500' },
+      amber: { bg: 'bg-amber-500/10', text: 'text-amber-500' },
+      violet: { bg: 'bg-violet-500/10', text: 'text-violet-500' },
+      emerald: { bg: 'bg-emerald-500/10', text: 'text-emerald-500' },
+      slate: { bg: 'bg-slate-500/10', text: 'text-slate-500' }
+    }
+    return colors[color] || colors.rose
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Hero Card */}
+      <Card className="bg-gradient-to-br from-rose-500/10 via-pink-500/5 to-purple-500/10 border-rose-500/20 overflow-hidden animate-fade-in-up">
+        <CardContent className="pt-8 pb-8 relative">
+          <div className="absolute top-0 right-0 w-48 h-48 bg-rose-500/5 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
+          <div className="flex flex-col items-center text-center relative">
+            <img
+              src={opNotesLogo}
+              alt="Op Notes"
+              className="h-16 w-16 rounded-2xl shadow-lg mb-4 transition-transform duration-200 hover:scale-105"
+            />
+            <h2 className="text-xl font-bold mb-2">Op Notes</h2>
+            <p className="text-muted-foreground max-w-md">
+              A free, open-source surgical notes management application for hospitals.
+              Manage patients, document surgeries, and print professional reports.
+            </p>
+            {appVersion && (
+              <span className="mt-3 text-xs text-muted-foreground/70 font-mono">
+                Version {appVersion}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Features Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {features.map((feature, index) => {
+          const colorClasses = getColorClasses(feature.color)
+          return (
+            <Card
+              key={feature.title}
+              className="animate-fade-in-up transition-all duration-200 hover:shadow-md"
+              style={{ animationDelay: `${(index + 1) * 50}ms` }}
+            >
+              <CardContent className="pt-4 pb-4">
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`h-9 w-9 rounded-lg ${colorClasses.bg} flex items-center justify-center flex-shrink-0`}
+                  >
+                    <div className={colorClasses.text}>{feature.icon}</div>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-sm mb-0.5">{feature.title}</h3>
+                    <p className="text-xs text-muted-foreground">{feature.description}</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+
+      {/* Links */}
+      <Card className="animate-fade-in-up" style={{ animationDelay: '350ms' }}>
+        <CardHeader className="pb-3 pt-4">
+          <CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Resources
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 space-y-3">
+          <Button
+            variant="outline"
+            className="w-full justify-start"
+            onClick={() => window.open('https://github.com/wavezync/opnotes', '_blank')}
+          >
+            <Code className="h-4 w-4 mr-2" />
+            View Source on GitHub
+            <ExternalLink className="h-3 w-3 ml-auto opacity-50" />
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* WaveZync Attribution */}
+      <div
+        className="flex flex-col items-center gap-2 pt-2 animate-fade-in-up"
+        style={{ animationDelay: '400ms' }}
+      >
+        <span className="text-xs text-muted-foreground">Made by</span>
+        <button
+          onClick={() => window.open('https://wavezync.com', '_blank')}
+          className="opacity-50 hover:opacity-80 transition-opacity"
+        >
+          <img src={wavezyncLogo} alt="WaveZync" className="h-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/support/CommunitySection.tsx
+++ b/src/renderer/src/components/support/CommunitySection.tsx
@@ -1,0 +1,110 @@
+import { Card, CardContent } from '@renderer/components/ui/card'
+import { Button } from '@renderer/components/ui/button'
+import { MessageCircle, Bell, HelpCircle, Users, ExternalLink } from 'lucide-react'
+
+export const CommunitySection = () => {
+  const benefits = [
+    {
+      icon: <Bell className="h-5 w-5" />,
+      title: 'Latest Updates',
+      description: 'Be the first to know about new releases and features.',
+      color: 'blue'
+    },
+    {
+      icon: <HelpCircle className="h-5 w-5" />,
+      title: 'Quick Support',
+      description: 'Get help from the team and experienced users.',
+      color: 'emerald'
+    },
+    {
+      icon: <Users className="h-5 w-5" />,
+      title: 'Connect',
+      description: 'Network with healthcare professionals worldwide.',
+      color: 'violet'
+    }
+  ]
+
+  const getColorClasses = (color: string) => {
+    const colors: Record<string, { bg: string; text: string }> = {
+      blue: { bg: 'bg-blue-500/10', text: 'text-blue-500' },
+      emerald: { bg: 'bg-emerald-500/10', text: 'text-emerald-500' },
+      violet: { bg: 'bg-violet-500/10', text: 'text-violet-500' }
+    }
+    return colors[color] || colors.blue
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="animate-fade-in-up">
+        <h2 className="text-lg font-semibold mb-1">Join Our Community</h2>
+        <p className="text-sm text-muted-foreground">
+          Connect with other Op Notes users and the WaveZync team.
+        </p>
+      </div>
+
+      {/* WhatsApp Hero */}
+      <Card
+        className="bg-gradient-to-br from-green-500/10 via-emerald-500/5 to-teal-500/10 border-green-500/20 overflow-hidden animate-fade-in-up"
+        style={{ animationDelay: '50ms' }}
+      >
+        <CardContent className="pt-8 pb-8 relative">
+          <div className="absolute top-0 right-0 w-48 h-48 bg-green-500/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
+          <div className="flex flex-col items-center text-center relative">
+            <div className="h-16 w-16 rounded-2xl bg-green-500/20 flex items-center justify-center mb-4 transition-transform duration-200 hover:scale-105">
+              <MessageCircle className="h-8 w-8 text-green-500" />
+            </div>
+            <h3 className="text-xl font-bold mb-2">WhatsApp Community</h3>
+            <p className="text-muted-foreground max-w-sm mb-6">
+              Join our active WhatsApp community to get instant support, share feedback,
+              and connect with healthcare professionals using Op Notes.
+            </p>
+            <Button
+              className="bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white"
+              onClick={() => window.open('https://chat.whatsapp.com/YOUR_INVITE_LINK', '_blank')}
+            >
+              <MessageCircle className="h-4 w-4 mr-2" />
+              Join WhatsApp Community
+              <ExternalLink className="h-3 w-3 ml-2" />
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Benefits Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {benefits.map((benefit, index) => {
+          const colorClasses = getColorClasses(benefit.color)
+          return (
+            <Card
+              key={benefit.title}
+              className="animate-fade-in-up"
+              style={{ animationDelay: `${(index + 2) * 50}ms` }}
+            >
+              <CardContent className="pt-5 pb-5 text-center">
+                <div
+                  className={`h-10 w-10 rounded-lg ${colorClasses.bg} flex items-center justify-center mx-auto mb-3`}
+                >
+                  <div className={colorClasses.text}>{benefit.icon}</div>
+                </div>
+                <h4 className="font-semibold text-sm mb-1">{benefit.title}</h4>
+                <p className="text-xs text-muted-foreground">{benefit.description}</p>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+
+      {/* Community Guidelines */}
+      <div
+        className="text-center text-xs text-muted-foreground animate-fade-in-up"
+        style={{ animationDelay: '250ms' }}
+      >
+        <p>
+          Our community is a friendly, respectful space for healthcare professionals.
+          Please be kind and helpful to fellow members.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/support/DocumentationHelp.tsx
+++ b/src/renderer/src/components/support/DocumentationHelp.tsx
@@ -1,0 +1,222 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@renderer/components/ui/card'
+import { Button } from '@renderer/components/ui/button'
+import {
+  BookOpen,
+  ExternalLink,
+  Rocket,
+  Users,
+  Stethoscope,
+  FileText,
+  Printer,
+  Keyboard,
+  Wand2,
+  RefreshCw,
+  ChevronRight
+} from 'lucide-react'
+import { useQueryClient, useMutation } from '@tanstack/react-query'
+import { queries } from '@renderer/lib/queries'
+
+interface GuideCardProps {
+  icon: React.ReactNode
+  title: string
+  description: string
+  color: string
+  onClick?: () => void
+}
+
+const GuideCard = ({ icon, title, description, color, onClick }: GuideCardProps) => {
+  const colorClasses: Record<string, { bg: string; text: string }> = {
+    blue: { bg: 'bg-blue-500/10', text: 'text-blue-500' },
+    emerald: { bg: 'bg-emerald-500/10', text: 'text-emerald-500' },
+    violet: { bg: 'bg-violet-500/10', text: 'text-violet-500' },
+    rose: { bg: 'bg-rose-500/10', text: 'text-rose-500' },
+    amber: { bg: 'bg-amber-500/10', text: 'text-amber-500' }
+  }
+
+  const classes = colorClasses[color] || colorClasses.blue
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left p-4 rounded-xl border bg-card hover:bg-accent/50 transition-all duration-200 group"
+    >
+      <div className="flex items-center gap-3">
+        <div className={`h-10 w-10 rounded-lg ${classes.bg} flex items-center justify-center flex-shrink-0`}>
+          <div className={classes.text}>{icon}</div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-sm mb-0.5 group-hover:text-foreground transition-colors">
+            {title}
+          </h4>
+          <p className="text-xs text-muted-foreground truncate">{description}</p>
+        </div>
+        <ChevronRight className="h-4 w-4 text-muted-foreground/50 group-hover:text-muted-foreground transition-colors" />
+      </div>
+    </button>
+  )
+}
+
+export const DocumentationHelp = () => {
+  const queryClient = useQueryClient()
+
+  const resetOnboardingMutation = useMutation({
+    mutationFn: async () => {
+      await window.api.invoke('updateSettings', [{ key: 'onboarding_completed', value: null }])
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queries.app.settings)
+    }
+  })
+
+  const guides = [
+    {
+      icon: <Rocket className="h-5 w-5" />,
+      title: 'Getting Started',
+      description: 'Set up Op Notes for your hospital',
+      color: 'blue'
+    },
+    {
+      icon: <Users className="h-5 w-5" />,
+      title: 'Managing Patients',
+      description: 'Add, search, and organize patient records',
+      color: 'emerald'
+    },
+    {
+      icon: <Stethoscope className="h-5 w-5" />,
+      title: 'Surgery Records',
+      description: 'Create and manage surgical notes',
+      color: 'rose'
+    },
+    {
+      icon: <FileText className="h-5 w-5" />,
+      title: 'Using Templates',
+      description: 'Create reusable surgery note templates',
+      color: 'violet'
+    },
+    {
+      icon: <Printer className="h-5 w-5" />,
+      title: 'Printing Records',
+      description: 'Print formatted BHT and surgery reports',
+      color: 'amber'
+    }
+  ]
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="animate-fade-in-up">
+        <h2 className="text-lg font-semibold mb-1">Documentation & Help</h2>
+        <p className="text-sm text-muted-foreground">
+          Learn how to get the most out of Op Notes.
+        </p>
+      </div>
+
+      {/* Quick Start Guides */}
+      <Card className="animate-fade-in-up" style={{ animationDelay: '50ms' }}>
+        <CardHeader className="pb-3 pt-4">
+          <div className="flex items-center gap-2.5">
+            <div className="h-8 w-8 rounded-lg bg-blue-500/10 flex items-center justify-center">
+              <BookOpen className="h-4 w-4 text-blue-500" />
+            </div>
+            <CardTitle className="text-sm font-medium">Quick Start Guides</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0 space-y-2">
+          {guides.map((guide, index) => (
+            <GuideCard
+              key={index}
+              icon={guide.icon}
+              title={guide.title}
+              description={guide.description}
+              color={guide.color}
+              onClick={() => window.open('https://github.com/wavezync/opnotes/wiki', '_blank')}
+            />
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Keyboard Shortcuts & Setup Wizard */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card className="animate-fade-in-up" style={{ animationDelay: '100ms' }}>
+          <CardContent className="pt-5 pb-5">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="h-10 w-10 rounded-lg bg-slate-500/10 flex items-center justify-center">
+                <Keyboard className="h-5 w-5 text-slate-500" />
+              </div>
+              <div>
+                <h4 className="font-medium text-sm">Keyboard Shortcuts</h4>
+                <p className="text-xs text-muted-foreground">Work faster with shortcuts</p>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => window.open('https://github.com/wavezync/opnotes/wiki/Keyboard-Shortcuts', '_blank')}
+            >
+              <Keyboard className="h-4 w-4 mr-2" />
+              View Shortcuts
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="animate-fade-in-up" style={{ animationDelay: '150ms' }}>
+          <CardContent className="pt-5 pb-5">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="h-10 w-10 rounded-lg bg-amber-500/10 flex items-center justify-center">
+                <Wand2 className="h-5 w-5 text-amber-500" />
+              </div>
+              <div>
+                <h4 className="font-medium text-sm">Setup Wizard</h4>
+                <p className="text-xs text-muted-foreground">Re-run the initial setup</p>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => resetOnboardingMutation.mutate()}
+              disabled={resetOnboardingMutation.isPending}
+            >
+              {resetOnboardingMutation.isPending ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Wand2 className="h-4 w-4 mr-2" />
+              )}
+              Run Setup Wizard
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* External Links */}
+      <Card className="animate-fade-in-up" style={{ animationDelay: '200ms' }}>
+        <CardHeader className="pb-3 pt-4">
+          <CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            More Resources
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 space-y-3">
+          <Button
+            variant="outline"
+            className="w-full justify-start"
+            onClick={() => window.open('https://github.com/wavezync/opnotes/wiki', '_blank')}
+          >
+            <BookOpen className="h-4 w-4 mr-2" />
+            Full Documentation
+            <ExternalLink className="h-3 w-3 ml-auto opacity-50" />
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full justify-start"
+            onClick={() => window.open('https://github.com/wavezync/opnotes/releases', '_blank')}
+          >
+            <FileText className="h-4 w-4 mr-2" />
+            Release Notes
+            <ExternalLink className="h-3 w-3 ml-auto opacity-50" />
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/renderer/src/components/support/ReportIssue.tsx
+++ b/src/renderer/src/components/support/ReportIssue.tsx
@@ -1,0 +1,141 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@renderer/components/ui/card'
+import { Button } from '@renderer/components/ui/button'
+import {
+  Bug,
+  ExternalLink,
+  AlertTriangle,
+  CheckCircle2,
+  Copy,
+  Check,
+  MessageCircle,
+  RefreshCw,
+  ListChecks,
+  Camera
+} from 'lucide-react'
+import { useSettings } from '@renderer/contexts/SettingsContext'
+import { useState } from 'react'
+
+export const ReportIssue = () => {
+  const { appVersion } = useSettings()
+  const [copied, setCopied] = useState(false)
+
+  const copyVersion = () => {
+    navigator.clipboard.writeText(`Op Notes v${appVersion}`)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const beforeReportingItems = [
+    { icon: <RefreshCw className="h-4 w-4" />, text: 'Try restarting the application' },
+    { icon: <ListChecks className="h-4 w-4" />, text: 'Check if the issue still occurs' },
+    { icon: <Camera className="h-4 w-4" />, text: 'Take screenshots if possible' }
+  ]
+
+  const includeItems = [
+    'Steps to reproduce the issue',
+    'What you expected to happen',
+    'What actually happened',
+    'Screenshots or screen recordings',
+    'Your operating system (Windows, macOS, Linux)'
+  ]
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="animate-fade-in-up">
+        <h2 className="text-lg font-semibold mb-1">Report an Issue</h2>
+        <p className="text-sm text-muted-foreground">
+          Found a bug? Let us know so we can fix it and improve Op Notes for everyone.
+        </p>
+      </div>
+
+      {/* Before Reporting */}
+      <Card
+        className="bg-gradient-to-br from-amber-500/5 to-amber-600/5 border-amber-500/20 animate-fade-in-up"
+        style={{ animationDelay: '50ms' }}
+      >
+        <CardHeader className="pb-3 pt-4">
+          <div className="flex items-center gap-2.5">
+            <div className="h-8 w-8 rounded-lg bg-amber-500/10 flex items-center justify-center">
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+            </div>
+            <CardTitle className="text-sm font-medium">Before You Report</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <ul className="space-y-2">
+            {beforeReportingItems.map((item, index) => (
+              <li key={index} className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span className="text-amber-500">{item.icon}</span>
+                {item.text}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      {/* What to Include */}
+      <Card className="animate-fade-in-up" style={{ animationDelay: '100ms' }}>
+        <CardHeader className="pb-3 pt-4">
+          <div className="flex items-center gap-2.5">
+            <div className="h-8 w-8 rounded-lg bg-blue-500/10 flex items-center justify-center">
+              <CheckCircle2 className="h-4 w-4 text-blue-500" />
+            </div>
+            <CardTitle className="text-sm font-medium">What to Include</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <ul className="space-y-2">
+            {includeItems.map((item, index) => (
+              <li key={index} className="flex items-start gap-2 text-sm text-muted-foreground">
+                <CheckCircle2 className="h-4 w-4 text-emerald-500 mt-0.5 flex-shrink-0" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      {/* Version Info */}
+      <Card className="animate-fade-in-up" style={{ animationDelay: '150ms' }}>
+        <CardContent className="py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs text-muted-foreground mb-0.5">Current Version</p>
+              <p className="font-mono text-sm font-medium">Op Notes v{appVersion}</p>
+            </div>
+            <Button variant="outline" size="sm" onClick={copyVersion}>
+              {copied ? (
+                <Check className="h-4 w-4 text-emerald-500" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* CTA */}
+      <div className="space-y-3 animate-fade-in-up" style={{ animationDelay: '200ms' }}>
+        <Button
+          className="w-full bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white"
+          onClick={() => window.open('https://github.com/wavezync/opnotes/issues/new?template=bug_report.yml', '_blank')}
+        >
+          <Bug className="h-4 w-4 mr-2" />
+          Report Issue on GitHub
+          <ExternalLink className="h-3 w-3 ml-2" />
+        </Button>
+        <p className="text-xs text-center text-muted-foreground">
+          <MessageCircle className="h-3 w-3 inline-block mr-1" />
+          Prefer chat? Join our{' '}
+          <button
+            onClick={() => window.open('https://chat.whatsapp.com/YOUR_INVITE_LINK', '_blank')}
+            className="text-green-500 hover:underline"
+          >
+            WhatsApp Community
+          </button>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/support/RequestFeature.tsx
+++ b/src/renderer/src/components/support/RequestFeature.tsx
@@ -1,0 +1,127 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@renderer/components/ui/card'
+import { Button } from '@renderer/components/ui/button'
+import {
+  Lightbulb,
+  ExternalLink,
+  MessageSquare,
+  Zap,
+  Target,
+  Users
+} from 'lucide-react'
+
+export const RequestFeature = () => {
+  const tips = [
+    {
+      icon: <MessageSquare className="h-4 w-4" />,
+      title: 'Describe the Problem',
+      description: 'What challenge are you facing that a new feature could solve?',
+      color: 'blue'
+    },
+    {
+      icon: <Lightbulb className="h-4 w-4" />,
+      title: 'Propose a Solution',
+      description: 'Share your idea for how the feature might work.',
+      color: 'amber'
+    },
+    {
+      icon: <Users className="h-4 w-4" />,
+      title: 'Share the Impact',
+      description: 'How would this help you and other healthcare professionals?',
+      color: 'emerald'
+    }
+  ]
+
+  const getColorClasses = (color: string) => {
+    const colors: Record<string, { bg: string; text: string }> = {
+      blue: { bg: 'bg-blue-500/10', text: 'text-blue-500' },
+      amber: { bg: 'bg-amber-500/10', text: 'text-amber-500' },
+      emerald: { bg: 'bg-emerald-500/10', text: 'text-emerald-500' }
+    }
+    return colors[color] || colors.amber
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="animate-fade-in-up">
+        <h2 className="text-lg font-semibold mb-1">Request a Feature</h2>
+        <p className="text-sm text-muted-foreground">
+          Have an idea to make Op Notes better? We would love to hear it.
+        </p>
+      </div>
+
+      {/* Inspiration Card */}
+      <Card
+        className="bg-gradient-to-br from-amber-500/10 via-orange-500/5 to-yellow-500/10 border-amber-500/20 overflow-hidden animate-fade-in-up"
+        style={{ animationDelay: '50ms' }}
+      >
+        <CardContent className="pt-6 pb-6 relative">
+          <div className="absolute top-0 right-0 w-32 h-32 bg-amber-500/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-2xl" />
+          <div className="flex items-start gap-4 relative">
+            <div className="h-12 w-12 rounded-xl bg-amber-500/20 flex items-center justify-center flex-shrink-0">
+              <Zap className="h-6 w-6 text-amber-500" />
+            </div>
+            <div>
+              <h3 className="font-semibold mb-1">Your Ideas Shape Op Notes</h3>
+              <p className="text-sm text-muted-foreground">
+                Every great feature starts with a user suggestion. Your workflow insights help us
+                build tools that truly serve healthcare professionals.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tips */}
+      <Card className="animate-fade-in-up" style={{ animationDelay: '100ms' }}>
+        <CardHeader className="pb-3 pt-4">
+          <div className="flex items-center gap-2.5">
+            <div className="h-8 w-8 rounded-lg bg-violet-500/10 flex items-center justify-center">
+              <Target className="h-4 w-4 text-violet-500" />
+            </div>
+            <CardTitle className="text-sm font-medium">Tips for a Great Request</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0 space-y-4">
+          {tips.map((tip, index) => {
+            const colorClasses = getColorClasses(tip.color)
+            return (
+              <div key={index} className="flex items-start gap-3">
+                <div
+                  className={`h-8 w-8 rounded-lg ${colorClasses.bg} flex items-center justify-center flex-shrink-0`}
+                >
+                  <div className={colorClasses.text}>{tip.icon}</div>
+                </div>
+                <div>
+                  <h4 className="text-sm font-medium mb-0.5">{tip.title}</h4>
+                  <p className="text-xs text-muted-foreground">{tip.description}</p>
+                </div>
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+
+      {/* CTA */}
+      <div className="space-y-3 animate-fade-in-up" style={{ animationDelay: '150ms' }}>
+        <Button
+          className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white"
+          onClick={() => window.open('https://github.com/wavezync/opnotes/issues/new?template=feature_request.yml', '_blank')}
+        >
+          <Lightbulb className="h-4 w-4 mr-2" />
+          Submit Feature Request
+          <ExternalLink className="h-3 w-3 ml-2" />
+        </Button>
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => window.open('https://github.com/wavezync/opnotes/discussions', '_blank')}
+        >
+          <MessageSquare className="h-4 w-4 mr-2" />
+          Join GitHub Discussions
+          <ExternalLink className="h-3 w-3 ml-2" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -23,6 +23,7 @@ import { AddNewDoctor } from './routes/doctors/add-doctor'
 import { EditDoctor } from './routes/doctors/edit-doctor'
 import { SurgierisIndex } from './routes/surgeries/list-surgeries'
 import { QuickAddSurgery } from './routes/surgeries/quick-add-surgery'
+import { SupportIndex } from './routes/support/support-index'
 import { SettingsIndex } from './routes/settings/settings-index'
 import { AddTemplatePage, EditTemplatePage } from './routes/settings/template-form-page'
 import { ActivityIndex } from './routes/activity/activity-index'
@@ -95,6 +96,11 @@ const router = createHashRouter([
       {
         path: '/quick-surgery',
         element: <QuickAddSurgery />
+      },
+
+      {
+        path: '/support',
+        element: <SupportIndex />
       },
 
       {

--- a/src/renderer/src/routes/support/support-index.tsx
+++ b/src/renderer/src/routes/support/support-index.tsx
@@ -1,0 +1,201 @@
+import { useBreadcrumbs } from '@renderer/contexts/BreadcrumbContext'
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { HeartHandshake, Info, Bug, Lightbulb, MessageCircle, BookOpen } from 'lucide-react'
+import { cn } from '@renderer/lib/utils'
+import { AboutWaveZync } from '@renderer/components/support/AboutWaveZync'
+import { ReportIssue } from '@renderer/components/support/ReportIssue'
+import { RequestFeature } from '@renderer/components/support/RequestFeature'
+import { CommunitySection } from '@renderer/components/support/CommunitySection'
+import { DocumentationHelp } from '@renderer/components/support/DocumentationHelp'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@renderer/components/ui/tabs'
+
+type SupportSection = 'about' | 'report-issue' | 'request-feature' | 'community' | 'documentation'
+
+interface NavItemProps {
+  icon: React.ReactNode
+  label: string
+  description: string
+  isActive: boolean
+  onClick: () => void
+  color: string
+}
+
+const NavItem = ({ icon, label, description, isActive, onClick, color }: NavItemProps) => (
+  <button
+    onClick={onClick}
+    className={cn(
+      'flex items-center gap-3 w-full px-3 py-3 text-left rounded-xl transition-all duration-200',
+      isActive ? 'bg-accent shadow-sm' : 'hover:bg-accent/50'
+    )}
+  >
+    <div
+      className={cn(
+        'h-9 w-9 rounded-lg flex items-center justify-center flex-shrink-0 transition-colors',
+        isActive ? color : 'bg-muted'
+      )}
+    >
+      <div className={cn(isActive ? 'text-white' : 'text-muted-foreground')}>{icon}</div>
+    </div>
+    <div className="min-w-0">
+      <div
+        className={cn(
+          'text-sm font-medium truncate',
+          isActive ? 'text-foreground' : 'text-muted-foreground'
+        )}
+      >
+        {label}
+      </div>
+      <div className="text-xs text-muted-foreground truncate">{description}</div>
+    </div>
+  </button>
+)
+
+export const SupportIndex = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { setBreadcrumbs } = useBreadcrumbs()
+
+  const tabParam = searchParams.get('tab')
+  const activeSection: SupportSection =
+    tabParam === 'report-issue'
+      ? 'report-issue'
+      : tabParam === 'request-feature'
+        ? 'request-feature'
+        : tabParam === 'community'
+          ? 'community'
+          : tabParam === 'documentation'
+            ? 'documentation'
+            : 'about'
+
+  const setActiveSection = (section: SupportSection) => {
+    setSearchParams(section === 'about' ? {} : { tab: section })
+  }
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: 'Support', to: '/support' }])
+  }, [setBreadcrumbs])
+
+  return (
+    <div className="h-full flex flex-col p-6 overflow-hidden">
+      {/* Header Section */}
+      <div className="flex items-center gap-3 mb-6 animate-fade-in-up">
+        <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-rose-500/20 to-pink-600/20 flex items-center justify-center border border-rose-500/20">
+          <HeartHandshake className="h-6 w-6 text-rose-500" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Support & Community</h1>
+          <p className="text-sm text-muted-foreground">
+            Get help, report issues, and connect with the Op Notes community
+          </p>
+        </div>
+      </div>
+
+      {/* Desktop layout with sidebar */}
+      <div className="hidden md:flex gap-6 flex-1 min-h-0">
+        <nav
+          className="w-56 flex-shrink-0 animate-fade-in-up"
+          style={{ animationDelay: '50ms' }}
+        >
+          <div className="space-y-1">
+            <NavItem
+              icon={<Info className="h-4 w-4" />}
+              label="About"
+              description="About Op Notes"
+              isActive={activeSection === 'about'}
+              onClick={() => setActiveSection('about')}
+              color="bg-rose-500"
+            />
+            <NavItem
+              icon={<Bug className="h-4 w-4" />}
+              label="Report Issue"
+              description="Report bugs"
+              isActive={activeSection === 'report-issue'}
+              onClick={() => setActiveSection('report-issue')}
+              color="bg-red-500"
+            />
+            <NavItem
+              icon={<Lightbulb className="h-4 w-4" />}
+              label="Request Feature"
+              description="Suggest ideas"
+              isActive={activeSection === 'request-feature'}
+              onClick={() => setActiveSection('request-feature')}
+              color="bg-amber-500"
+            />
+            <NavItem
+              icon={<MessageCircle className="h-4 w-4" />}
+              label="Community"
+              description="Join the chat"
+              isActive={activeSection === 'community'}
+              onClick={() => setActiveSection('community')}
+              color="bg-green-500"
+            />
+            <NavItem
+              icon={<BookOpen className="h-4 w-4" />}
+              label="Documentation"
+              description="Help & guides"
+              isActive={activeSection === 'documentation'}
+              onClick={() => setActiveSection('documentation')}
+              color="bg-blue-500"
+            />
+          </div>
+        </nav>
+        <div
+          className="flex-1 min-w-0 overflow-y-auto animate-fade-in-up"
+          style={{ animationDelay: '100ms' }}
+        >
+          {activeSection === 'about' && <AboutWaveZync />}
+          {activeSection === 'report-issue' && <ReportIssue />}
+          {activeSection === 'request-feature' && <RequestFeature />}
+          {activeSection === 'community' && <CommunitySection />}
+          {activeSection === 'documentation' && <DocumentationHelp />}
+        </div>
+      </div>
+
+      {/* Mobile layout with tabs */}
+      <div className="md:hidden flex-1 min-h-0 overflow-y-auto">
+        <Tabs
+          value={activeSection}
+          onValueChange={(value) => setActiveSection(value as SupportSection)}
+        >
+          <TabsList className="w-full flex-wrap h-auto gap-1 p-1">
+            <TabsTrigger value="about" className="flex-1 min-w-[80px]">
+              <Info className="h-4 w-4 mr-1" />
+              About
+            </TabsTrigger>
+            <TabsTrigger value="report-issue" className="flex-1 min-w-[80px]">
+              <Bug className="h-4 w-4 mr-1" />
+              Issues
+            </TabsTrigger>
+            <TabsTrigger value="request-feature" className="flex-1 min-w-[80px]">
+              <Lightbulb className="h-4 w-4 mr-1" />
+              Features
+            </TabsTrigger>
+            <TabsTrigger value="community" className="flex-1 min-w-[80px]">
+              <MessageCircle className="h-4 w-4 mr-1" />
+              Community
+            </TabsTrigger>
+            <TabsTrigger value="documentation" className="flex-1 min-w-[80px]">
+              <BookOpen className="h-4 w-4 mr-1" />
+              Docs
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="about" className="mt-4">
+            <AboutWaveZync />
+          </TabsContent>
+          <TabsContent value="report-issue" className="mt-4">
+            <ReportIssue />
+          </TabsContent>
+          <TabsContent value="request-feature" className="mt-4">
+            <RequestFeature />
+          </TabsContent>
+          <TabsContent value="community" className="mt-4">
+            <CommunitySection />
+          </TabsContent>
+          <TabsContent value="documentation" className="mt-4">
+            <DocumentationHelp />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add a new **Support** section in the sidebar (positioned above Settings) with `HeartHandshake` icon
- Five tabbed pages: About, Report Issue, Request Feature, Community, and Documentation
- GitHub issue templates for structured bug reports and feature requests

## New Pages

### About
- Showcases Op Notes features (Surgery Management, Patient Records, Templates, Print Reports, Quick Search, Privacy First)
- Displays current app version
- WaveZync attribution at the bottom

### Report Issue
- Guidance on what to check before reporting
- Checklist of information to include
- Version display with copy button
- Direct link to GitHub issues

### Request Feature
- Tips for writing effective feature requests
- Links to GitHub issues and discussions

### Community
- WhatsApp community join card
- Benefits of joining (Updates, Quick Support, Connect)

### Documentation
- Quick start guide cards linking to GitHub wiki
- Keyboard shortcuts link
- Setup wizard re-run button
- Links to full docs and release notes

## GitHub Issue Templates

- `bug_report.yml` - Structured bug report with OS dropdown, version field, reproduction steps
- `feature_request.yml` - Feature request with impact assessment
- `config.yml` - Disables blank issues, adds contact links

## Test plan

- [ ] Click "Support" in sidebar - should navigate to `/support`
- [ ] Verify all 5 tabs work correctly
- [ ] Test external links open in browser (GitHub, WhatsApp)
- [ ] Test version copy button in Report Issue
- [ ] Test "Run Setup Wizard" button in Documentation
- [ ] Verify responsive layout on mobile (tabs)
- [ ] Check styling in both light and dark themes