### PR TITLE
feat: add inline editing for surgery view page

### DIFF
--- a/src/renderer/src/components/surgery/inline-edit/EditableFieldCard.tsx
+++ b/src/renderer/src/components/surgery/inline-edit/EditableFieldCard.tsx
@@ -1,0 +1,50 @@
+import { cn } from '@renderer/lib/utils'
+import { Card, CardContent, CardHeader, CardTitle } from '@renderer/components/ui/card'
+import { LucideIcon } from 'lucide-react'
+import { ReactNode } from 'react'
+
+export interface EditableFieldCardProps {
+  /** Card title */
+  title: string
+  /** Icon component */
+  icon: LucideIcon
+  /** Icon background color class */
+  iconBgColor: string
+  /** Icon color class */
+  iconColor: string
+  /** Card content */
+  children: ReactNode
+  /** Additional class name for the card */
+  className?: string
+  /** Animation delay for entrance animation */
+  animationDelay?: number
+}
+
+export const EditableFieldCard = ({
+  title,
+  icon: Icon,
+  iconBgColor,
+  iconColor,
+  children,
+  className,
+  animationDelay = 0
+}: EditableFieldCardProps) => {
+  return (
+    <Card
+      className={cn('bg-gradient-to-br from-card to-card/80 animate-fade-in-up', className)}
+      style={{ animationDelay: `${animationDelay}ms` }}
+    >
+      <CardHeader className="pb-3 pt-4">
+        <div className="flex items-center gap-2.5">
+          <div className={cn('h-8 w-8 rounded-lg flex items-center justify-center', iconBgColor)}>
+            <Icon className={cn('h-4 w-4', iconColor)} />
+          </div>
+          <CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            {title}
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">{children}</CardContent>
+    </Card>
+  )
+}

--- a/src/renderer/src/components/surgery/inline-edit/InlineEditableDate.tsx
+++ b/src/renderer/src/components/surgery/inline-edit/InlineEditableDate.tsx
@@ -1,0 +1,101 @@
+import { cn, formatDate } from '@renderer/lib/utils'
+import { Button } from '@renderer/components/ui/button'
+import { Calendar } from '@renderer/components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { Pencil, X } from 'lucide-react'
+import { useState, useCallback } from 'react'
+
+export interface InlineEditableDateProps {
+  /** Current date value */
+  value: Date | null | undefined
+  /** Called when date is saved */
+  onSave: (value: Date | null) => Promise<void>
+  /** Placeholder for empty state */
+  emptyPlaceholder?: string
+  /** Additional class name */
+  className?: string
+}
+
+export const InlineEditableDate = ({
+  value,
+  onSave,
+  emptyPlaceholder = 'Select date...',
+  className
+}: InlineEditableDateProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const isEmpty = !value
+
+  const handleSelect = useCallback(
+    async (date: Date | undefined) => {
+      setIsSaving(true)
+      try {
+        await onSave(date || null)
+        setIsOpen(false)
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [onSave]
+  )
+
+  const handleClear = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation()
+      setIsSaving(true)
+      try {
+        await onSave(null)
+        setIsOpen(false)
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [onSave]
+  )
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <div
+          className={cn(
+            'group inline-flex items-center gap-2 cursor-pointer transition-all duration-200 rounded px-1 -mx-1',
+            isEmpty ? 'text-muted-foreground/60' : '',
+            'hover:bg-accent/50',
+            className
+          )}
+          role="button"
+          tabIndex={0}
+        >
+          <span className="text-sm font-medium">
+            {isEmpty ? emptyPlaceholder : formatDate(value)}
+          </span>
+          <Pencil className="h-3 w-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 transition-opacity" />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={value || undefined}
+          onSelect={handleSelect}
+          initialFocus
+          disabled={isSaving}
+        />
+        {value && (
+          <div className="px-3 pb-3 border-t pt-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full text-muted-foreground"
+              onClick={handleClear}
+              disabled={isSaving}
+            >
+              <X className="h-4 w-4 mr-2" />
+              Clear date
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/surgery/inline-edit/InlineEditableDoctors.tsx
+++ b/src/renderer/src/components/surgery/inline-edit/InlineEditableDoctors.tsx
@@ -1,0 +1,273 @@
+import { cn } from '@renderer/lib/utils'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { Check, Pencil, Save, X, Search, UserPlus } from 'lucide-react'
+import { useState, useCallback, useMemo, useRef } from 'react'
+import { DoctorModel } from '@shared/models/DoctorModel'
+import { useQuery } from '@tanstack/react-query'
+import { queries } from '@renderer/lib/queries'
+import { Input } from '@renderer/components/ui/input'
+import { Checkbox } from '@renderer/components/ui/checkbox'
+import { ScrollArea } from '@renderer/components/ui/scroll-area'
+import { Link } from 'react-router-dom'
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@renderer/components/ui/sheet'
+import { AddOrEditDoctor, AddOrEditDoctorRef } from '@renderer/components/doctor/AddOrEditDoctor'
+
+export interface InlineEditableDoctorsProps {
+  /** Currently assigned doctors */
+  doctors: DoctorModel[] | undefined
+  /** Called when doctors are saved */
+  onSave: (doctorIds: number[]) => Promise<void>
+  /** Placeholder for empty state */
+  emptyPlaceholder?: string
+  /** Label for the doctor type (e.g., "surgeons", "assistants") */
+  doctorTypeLabel?: string
+  /** Additional class name */
+  className?: string
+}
+
+export const InlineEditableDoctors = ({
+  doctors,
+  onSave,
+  emptyPlaceholder = 'No doctors assigned',
+  doctorTypeLabel = 'doctors',
+  className
+}: InlineEditableDoctorsProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [search, setSearch] = useState('')
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const [addNewSheetOpen, setAddNewSheetOpen] = useState(false)
+  const addDoctorFormRef = useRef<AddOrEditDoctorRef>(null)
+
+  const isEmpty = !doctors || doctors.length === 0
+
+  // Fetch all doctors for selection
+  const { data: doctorList, refetch } = useQuery({
+    ...queries.doctors.list({ pageSize: 100, search })
+  })
+
+  // Filter doctors based on search
+  const filteredDoctors = useMemo(() => {
+    const doctors = doctorList?.data || []
+    if (!search.trim()) return doctors
+    const searchLower = search.toLowerCase()
+    return doctors.filter(
+      (d) =>
+        d.name.toLowerCase().includes(searchLower) ||
+        d.designation?.toLowerCase().includes(searchLower)
+    )
+  }, [doctorList?.data, search])
+
+  const handleOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        // Initialize selection with current doctors
+        setSelectedIds(doctors?.map((d) => d.id) || [])
+        setSearch('')
+      }
+      setIsOpen(open)
+    },
+    [doctors]
+  )
+
+  const handleToggleDoctor = useCallback((doctorId: number, checked: boolean) => {
+    setSelectedIds((prev) => (checked ? [...prev, doctorId] : prev.filter((id) => id !== doctorId)))
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+    try {
+      await onSave(selectedIds)
+      setIsOpen(false)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [selectedIds, onSave])
+
+  const handleNewDoctor = useCallback(
+    (doctor: DoctorModel) => {
+      setSelectedIds((prev) => [...prev, doctor.id])
+      setAddNewSheetOpen(false)
+      refetch()
+    },
+    [refetch]
+  )
+
+  return (
+    <>
+      <Popover open={isOpen} onOpenChange={handleOpen}>
+        <PopoverTrigger asChild>
+          <div
+            className={cn(
+              'group cursor-pointer transition-all duration-200 rounded-lg',
+              'hover:bg-accent/30',
+              className
+            )}
+            role="button"
+            tabIndex={0}
+          >
+            {isEmpty ? (
+              <div className="flex items-center gap-2 py-2 px-1 text-muted-foreground/60">
+                <span className="text-sm">{emptyPlaceholder}</span>
+                <Pencil className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </div>
+            ) : (
+              <div className="relative">
+                <ul className="space-y-1.5 py-1">
+                  {doctors.map((doctor) => (
+                    <li key={doctor.id} className="flex items-center gap-2 text-sm">
+                      <div className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                      <span>
+                        <Link
+                          to={`/doctors/${doctor.id}/edit`}
+                          className="hover:text-primary hover:underline transition-colors"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Dr. {doctor.name}
+                        </Link>
+                        {doctor.designation && (
+                          <span className="text-muted-foreground ml-1">({doctor.designation})</span>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                {/* Edit hint on hover */}
+                <div className="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-1 px-2 py-1 rounded-md bg-background/80 backdrop-blur-sm border text-xs text-muted-foreground">
+                    <Pencil className="h-3 w-3" />
+                    <span>Edit</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent className="w-80 p-0" align="start">
+          <div className="p-3 border-b">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={`Search ${doctorTypeLabel}...`}
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          <ScrollArea className="h-[240px]">
+            <div className="p-2">
+              {filteredDoctors.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  No {doctorTypeLabel} found
+                </p>
+              ) : (
+                filteredDoctors.map((doctor) => (
+                  <label
+                    key={doctor.id}
+                    className="flex items-center gap-3 p-2 rounded-md hover:bg-accent cursor-pointer"
+                  >
+                    <Checkbox
+                      checked={selectedIds.includes(doctor.id)}
+                      onCheckedChange={(checked) =>
+                        handleToggleDoctor(doctor.id, checked as boolean)
+                      }
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">Dr. {doctor.name}</p>
+                      {doctor.designation && (
+                        <p className="text-xs text-muted-foreground truncate">
+                          {doctor.designation}
+                        </p>
+                      )}
+                    </div>
+                    {selectedIds.includes(doctor.id) && (
+                      <Check className="h-4 w-4 text-emerald-500 flex-shrink-0" />
+                    )}
+                  </label>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+
+          <div className="p-2 border-t bg-muted/30">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-muted-foreground"
+              onClick={() => setAddNewSheetOpen(true)}
+            >
+              <UserPlus className="h-4 w-4 mr-2" />
+              Add new doctor
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 p-3 border-t">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsOpen(false)}
+              disabled={isSaving}
+            >
+              <X className="h-4 w-4 mr-1" />
+              Cancel
+            </Button>
+            <Button variant="default" size="sm" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? (
+                'Saving...'
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-1" />
+                  Save
+                </>
+              )}
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Add new doctor sheet */}
+      <Sheet open={addNewSheetOpen} onOpenChange={setAddNewSheetOpen}>
+        <SheetContent className="sm:max-w-none w-[480px] flex flex-col">
+          <SheetHeader className="pb-4 border-b">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-xl bg-blue-500/10 flex items-center justify-center">
+                <UserPlus className="h-5 w-5 text-blue-500" />
+              </div>
+              <div>
+                <SheetTitle className="text-lg">Add New Doctor</SheetTitle>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  Add a new doctor to the system
+                </p>
+              </div>
+            </div>
+          </SheetHeader>
+
+          <div className="flex-1 py-4">
+            <AddOrEditDoctor ref={addDoctorFormRef} onUpdated={handleNewDoctor} />
+          </div>
+
+          <SheetFooter className="pt-4 border-t">
+            <Button
+              variant="gradient"
+              onClick={() => {
+                addDoctorFormRef.current?.submit()
+              }}
+            >
+              <Save className="h-4 w-4 mr-2" />
+              Save Doctor
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/renderer/src/components/surgery/inline-edit/InlineEditableField.tsx
+++ b/src/renderer/src/components/surgery/inline-edit/InlineEditableField.tsx
@@ -1,0 +1,177 @@
+import { cn } from '@renderer/lib/utils'
+import { Button } from '@renderer/components/ui/button'
+import { Check, X, Pencil, Plus } from 'lucide-react'
+import { useCallback, useEffect, useState, ReactNode } from 'react'
+
+export interface InlineEditableFieldProps {
+  /** Whether the field has no content */
+  isEmpty: boolean
+  /** Placeholder text for empty state */
+  emptyPlaceholder?: string
+  /** Whether currently in edit mode */
+  isEditing: boolean
+  /** Called when user wants to enter edit mode */
+  onEdit: () => void
+  /** Called when saving */
+  onSave: () => Promise<void>
+  /** Called when canceling edit */
+  onCancel: () => void
+  /** Whether save is in progress */
+  isSaving: boolean
+  /** Content to display in view mode */
+  children: ReactNode
+  /** Editor content to display in edit mode */
+  editor: ReactNode
+  /** Additional class names */
+  className?: string
+  /** Whether to show action buttons in footer or inline */
+  actionsPosition?: 'footer' | 'inline'
+}
+
+export const InlineEditableField = ({
+  isEmpty,
+  emptyPlaceholder = 'Click to add...',
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+  isSaving,
+  children,
+  editor,
+  className,
+  actionsPosition = 'footer'
+}: InlineEditableFieldProps) => {
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const handleSave = useCallback(async () => {
+    setSaveError(null)
+    try {
+      await onSave()
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Failed to save')
+    }
+  }, [onSave])
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    if (!isEditing) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Escape to cancel
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      }
+      // Cmd/Ctrl + Enter to save
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        handleSave()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isEditing, onCancel, handleSave])
+
+  // View mode
+  if (!isEditing) {
+    return (
+      <div
+        className={cn(
+          'group relative cursor-pointer transition-all duration-200',
+          isEmpty
+            ? 'border-2 border-dashed border-muted-foreground/20 rounded-lg hover:border-muted-foreground/40 hover:bg-accent/30'
+            : 'hover:bg-accent/20 rounded-lg',
+          className
+        )}
+        onClick={onEdit}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onEdit()
+          }
+        }}
+      >
+        {isEmpty ? (
+          // Empty state
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <div className="h-10 w-10 rounded-lg bg-muted/50 flex items-center justify-center mb-2 group-hover:bg-muted transition-colors">
+              <Plus className="h-5 w-5 text-muted-foreground/50 group-hover:text-muted-foreground transition-colors" />
+            </div>
+            <p className="text-sm text-muted-foreground/60 group-hover:text-muted-foreground transition-colors">
+              {emptyPlaceholder}
+            </p>
+          </div>
+        ) : (
+          // Content with hover hint
+          <div className="relative">
+            <div className="p-4 rounded-lg bg-accent/30">{children}</div>
+            {/* Edit hint on hover */}
+            <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="flex items-center gap-1 px-2 py-1 rounded-md bg-background/80 backdrop-blur-sm border text-xs text-muted-foreground">
+                <Pencil className="h-3 w-3" />
+                <span>Click to edit</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Edit mode
+  return (
+    <div
+      className={cn(
+        'rounded-lg border-2 border-primary/50 ring-4 ring-primary/10 transition-all duration-200',
+        className
+      )}
+    >
+      <div className="p-1">{editor}</div>
+
+      {actionsPosition === 'footer' && (
+        <div className="flex items-center justify-between px-3 py-2 bg-muted/30 border-t">
+          <div className="text-xs text-muted-foreground">
+            <kbd className="px-1.5 py-0.5 rounded bg-muted text-[10px] font-mono">Esc</kbd>
+            <span className="ml-1">to cancel</span>
+          </div>
+
+          {saveError && <p className="text-xs text-destructive mx-4">{saveError}</p>}
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation()
+                onCancel()
+              }}
+              disabled={isSaving}
+            >
+              <X className="h-4 w-4 mr-1" />
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation()
+                handleSave()
+              }}
+              isLoading={isSaving}
+              loadingText="Saving..."
+            >
+              <Check className="h-4 w-4 mr-1" />
+              Save
+              <kbd className="ml-2 px-1 py-0.5 rounded bg-primary-foreground/20 text-[10px] font-mono">
+                {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}↵
+              </kbd>
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/surgery/inline-edit/InlineEditableRichText.tsx
+++ b/src/renderer/src/components/surgery/inline-edit/InlineEditableRichText.tsx
@@ -1,0 +1,90 @@
+import { cn, isEmptyHtml } from '@renderer/lib/utils'
+import { RichTextEditor } from '@renderer/components/common/RichTextEditor'
+import { InlineEditableField } from './InlineEditableField'
+import { useState, useCallback } from 'react'
+
+export interface InlineEditableRichTextProps {
+  /** Current HTML content */
+  value: string | null | undefined
+  /** Called when content is saved */
+  onSave: (content: string) => Promise<void>
+  /** Placeholder for empty state */
+  emptyPlaceholder?: string
+  /** Whether to show template button in editor */
+  showTemplateButton?: boolean
+  /** Additional class name */
+  className?: string
+}
+
+// Rich text content display component
+const RichTextContent = ({ content, className }: { content: string; className?: string }) => (
+  <div
+    className={cn(
+      'prose prose-lead:normal prose-p:m-0 prose-li:m-0 [overflow-wrap:anywhere] dark:prose-invert prose-sm sm:prose-base',
+      'focus:outline-none max-w-none',
+      className
+    )}
+    dangerouslySetInnerHTML={{ __html: content || '' }}
+  />
+)
+
+export const InlineEditableRichText = ({
+  value,
+  onSave,
+  emptyPlaceholder = 'Click to add content...',
+  showTemplateButton = true,
+  className
+}: InlineEditableRichTextProps) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [editedContent, setEditedContent] = useState<string>(value || '')
+
+  const isEmpty = isEmptyHtml(value)
+
+  const handleEdit = useCallback(() => {
+    setEditedContent(value || '')
+    setIsEditing(true)
+  }, [value])
+
+  const handleCancel = useCallback(() => {
+    setEditedContent(value || '')
+    setIsEditing(false)
+  }, [value])
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+    try {
+      await onSave(editedContent)
+      setIsEditing(false)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [editedContent, onSave])
+
+  const handleEditorUpdate = useCallback((content: string) => {
+    setEditedContent(content)
+  }, [])
+
+  return (
+    <InlineEditableField
+      isEmpty={isEmpty}
+      emptyPlaceholder={emptyPlaceholder}
+      isEditing={isEditing}
+      onEdit={handleEdit}
+      onSave={handleSave}
+      onCancel={handleCancel}
+      isSaving={isSaving}
+      className={className}
+      editor={
+        <RichTextEditor
+          initialContent={editedContent}
+          onUpdate={handleEditorUpdate}
+          showTemplateButton={showTemplateButton}
+          editorClassName="border m-1 rounded-md overflow-y-auto max-h-64 min-h-32"
+        />
+      }
+    >
+      <RichTextContent content={value || ''} />
+    </InlineEditableField>
+  )
+}

--- a/src/renderer/src/components/surgery/inline-edit/InlineEditableText.tsx
+++ b/src/renderer/src/components/surgery/inline-edit/InlineEditableText.tsx
@@ -1,0 +1,144 @@
+import { cn } from '@renderer/lib/utils'
+import { Input } from '@renderer/components/ui/input'
+import { Button } from '@renderer/components/ui/button'
+import { Check, X, Pencil } from 'lucide-react'
+import { useState, useCallback, useRef, useEffect, KeyboardEvent } from 'react'
+
+export interface InlineEditableTextProps {
+  /** Current value */
+  value: string | null | undefined
+  /** Called when value is saved */
+  onSave: (value: string) => Promise<void>
+  /** Placeholder for empty state */
+  emptyPlaceholder?: string
+  /** Placeholder for input */
+  inputPlaceholder?: string
+  /** Whether the text should be displayed as monospace */
+  mono?: boolean
+  /** Additional class name */
+  className?: string
+}
+
+export const InlineEditableText = ({
+  value,
+  onSave,
+  emptyPlaceholder = 'Click to add...',
+  inputPlaceholder = 'Enter value...',
+  mono = false,
+  className
+}: InlineEditableTextProps) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [editedValue, setEditedValue] = useState<string>(value || '')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const isEmpty = !value || value.trim().length === 0
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  const handleEdit = useCallback(() => {
+    setEditedValue(value || '')
+    setIsEditing(true)
+  }, [value])
+
+  const handleCancel = useCallback(() => {
+    setEditedValue(value || '')
+    setIsEditing(false)
+  }, [value])
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+    try {
+      await onSave(editedValue)
+      setIsEditing(false)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [editedValue, onSave])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleSave()
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        handleCancel()
+      }
+    },
+    [handleSave, handleCancel]
+  )
+
+  // View mode
+  if (!isEditing) {
+    return (
+      <div
+        className={cn(
+          'group inline-flex items-center gap-2 cursor-pointer transition-all duration-200 rounded px-1 -mx-1',
+          isEmpty ? 'text-muted-foreground/60' : '',
+          'hover:bg-accent/50',
+          className
+        )}
+        onClick={handleEdit}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleEdit()
+          }
+        }}
+      >
+        <span className={cn('text-sm font-medium', mono && 'font-mono')}>
+          {isEmpty ? emptyPlaceholder : value}
+        </span>
+        <Pencil className="h-3 w-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 transition-opacity" />
+      </div>
+    )
+  }
+
+  // Edit mode
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <Input
+        ref={inputRef}
+        value={editedValue}
+        onChange={(e) => setEditedValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={inputPlaceholder}
+        className={cn('h-8 text-sm', mono && 'font-mono')}
+        disabled={isSaving}
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={(e) => {
+          e.stopPropagation()
+          handleCancel()
+        }}
+        disabled={isSaving}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="default"
+        size="icon"
+        className="h-8 w-8"
+        onClick={(e) => {
+          e.stopPropagation()
+          handleSave()
+        }}
+        disabled={isSaving}
+      >
+        <Check className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/surgery/inline-edit/index.ts
+++ b/src/renderer/src/components/surgery/inline-edit/index.ts
@@ -1,0 +1,17 @@
+export { InlineEditableField } from './InlineEditableField'
+export type { InlineEditableFieldProps } from './InlineEditableField'
+
+export { InlineEditableRichText } from './InlineEditableRichText'
+export type { InlineEditableRichTextProps } from './InlineEditableRichText'
+
+export { InlineEditableText } from './InlineEditableText'
+export type { InlineEditableTextProps } from './InlineEditableText'
+
+export { InlineEditableDate } from './InlineEditableDate'
+export type { InlineEditableDateProps } from './InlineEditableDate'
+
+export { InlineEditableDoctors } from './InlineEditableDoctors'
+export type { InlineEditableDoctorsProps } from './InlineEditableDoctors'
+
+export { EditableFieldCard } from './EditableFieldCard'
+export type { EditableFieldCardProps } from './EditableFieldCard'


### PR DESCRIPTION
## Summary

Transform the surgery view page into an editable document where staff can quickly update any field before printing.

- Add inline edit components (rich text, text, date, doctors)
- All fields always visible with click-to-add placeholders
- Each field saves independently with toast notifications
- Keyboard shortcuts: Esc to cancel, Cmd/Ctrl+Enter to save
- Display notes cards as full-width rows for easier editing
- Rename "Edit" button to "Edit All" for bulk editing

## Test plan

- [ ] Open a surgery view page
- [ ] Click on any field to enter edit mode
- [ ] Verify save/cancel buttons work
- [ ] Test keyboard shortcuts (Esc, Cmd+Enter)
- [ ] Verify changes persist after refresh
- [ ] Test the "Edit All" button still navigates to full edit page